### PR TITLE
add bottom alignement for tooltips in 1.8.9 

### DIFF
--- a/1.19.3/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.19.3/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
@@ -42,17 +43,31 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 @Mixin(Screen.class)
 public abstract class ScreenMixin {
 
-	@ModifyArgs(method = "renderTooltip(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/item/ItemStack;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderTooltip(Lnet/minecraft/client/util/math/MatrixStack;Ljava/util/List;Ljava/util/Optional;II)V"))
-	public void axolotlclient$modifyTooltipPosition(Args args) {
+	@ModifyVariable(method = "renderTooltipFromComponents",
+		at = @At("STORE"), index = 8)
+	private int axolotlclient$scrollableTooltipsX(int x){
 		if (ScrollableTooltips.getInstance().enabled.get()) {
 			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
-				&& ((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).m_zqfbkfzl()) {
-				return;
+				&& !((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).m_zqfbkfzl()) {
+				return x;
 			}
 
-			args.set(3, (int) args.get(3) + ScrollableTooltips.getInstance().tooltipOffsetX);
-			args.set(4, (int) args.get(4) + ScrollableTooltips.getInstance().tooltipOffsetY);
+			return x + ScrollableTooltips.getInstance().tooltipOffsetX;
 		}
+		return x;
+	}
+
+	@ModifyVariable(method = "renderTooltipFromComponents",
+		at = @At("STORE"), index = 9)
+	private int axolotlclient$scrollableTooltipsY(int y){
+		if (ScrollableTooltips.getInstance().enabled.get()) {
+			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
+				&& !((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).m_zqfbkfzl()) {
+				return y;
+			}
+			return y + ScrollableTooltips.getInstance().tooltipOffsetY;
+		}
+		return y;
 	}
 
 	@Inject(method = "handleTextClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/ClickEvent;getAction()Lnet/minecraft/text/ClickEvent$Action;", ordinal = 0), cancellable = true)

--- a/1.19.3/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.19.3/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -34,11 +34,9 @@ import net.minecraft.text.Style;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(Screen.class)
 public abstract class ScreenMixin {

--- a/1.19.4/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.19.4/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -34,11 +34,9 @@ import net.minecraft.text.Style;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(Screen.class)
 public abstract class ScreenMixin {

--- a/1.19.4/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.19.4/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -35,6 +35,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyArgs;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
@@ -42,17 +43,31 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 @Mixin(Screen.class)
 public abstract class ScreenMixin {
 
-	@ModifyArgs(method = "renderTooltip(Lnet/minecraft/client/util/math/MatrixStack;Lnet/minecraft/item/ItemStack;II)V", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/screen/Screen;renderTooltip(Lnet/minecraft/client/util/math/MatrixStack;Ljava/util/List;Ljava/util/Optional;II)V"))
-	public void axolotlclient$modifyTooltipPosition(Args args) {
+	@ModifyVariable(method = "renderTooltipFromComponents",
+		at = @At("STORE"), index = 11)
+	private int axolotlclient$scrollableTooltipsX(int x){
 		if (ScrollableTooltips.getInstance().enabled.get()) {
 			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
-				&& ((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).isInventoryOpen()) {
-				return;
+				&& !((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).isInventoryOpen()) {
+				return x;
 			}
 
-			args.set(3, (int) args.get(3) + ScrollableTooltips.getInstance().tooltipOffsetX);
-			args.set(4, (int) args.get(4) + ScrollableTooltips.getInstance().tooltipOffsetY);
+			return x + ScrollableTooltips.getInstance().tooltipOffsetX;
 		}
+		return x;
+	}
+
+	@ModifyVariable(method = "renderTooltipFromComponents",
+		at = @At("STORE"), index = 12)
+	private int axolotlclient$scrollableTooltipsY(int y){
+		if (ScrollableTooltips.getInstance().enabled.get()) {
+			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
+				&& !((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).isInventoryOpen()) {
+				return y;
+			}
+			return y + ScrollableTooltips.getInstance().tooltipOffsetY;
+		}
+		return y;
 	}
 
 	@Inject(method = "handleTextClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/ClickEvent;getAction()Lnet/minecraft/text/ClickEvent$Action;", ordinal = 0), cancellable = true)

--- a/1.20/src/main/java/io/github/axolotlclient/mixin/GuiGraphicsMixin.java
+++ b/1.20/src/main/java/io/github/axolotlclient/mixin/GuiGraphicsMixin.java
@@ -1,0 +1,48 @@
+package io.github.axolotlclient.mixin;
+
+import java.util.List;
+
+import io.github.axolotlclient.modules.scrollableTooltips.ScrollableTooltips;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.font.TextRenderer;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
+import net.minecraft.client.gui.tooltip.TooltipComponent;
+import net.minecraft.client.gui.tooltip.TooltipPositioner;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiGraphics.class)
+public class GuiGraphicsMixin {
+
+	@ModifyVariable(method = "drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;IILnet/minecraft/client/gui/tooltip/TooltipPositioner;)V",
+		at = @At("STORE"), index = 11)
+	private int axolotlclient$scrollableTooltipsX(int x){
+		if (ScrollableTooltips.getInstance().enabled.get()) {
+			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
+				&& !((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).isInventoryOpen()) {
+				return x;
+			}
+
+			return x + ScrollableTooltips.getInstance().tooltipOffsetX;
+		}
+		return x;
+	}
+
+	@ModifyVariable(method = "drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;IILnet/minecraft/client/gui/tooltip/TooltipPositioner;)V",
+		at = @At("STORE"), index = 12)
+	private int axolotlclient$scrollableTooltipsY(int y){
+		if (ScrollableTooltips.getInstance().enabled.get()) {
+			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
+				&& !((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).isInventoryOpen()) {
+				return y;
+			}
+			return y + ScrollableTooltips.getInstance().tooltipOffsetY;
+		}
+		return y;
+	}
+
+}

--- a/1.20/src/main/java/io/github/axolotlclient/mixin/GuiGraphicsMixin.java
+++ b/1.20/src/main/java/io/github/axolotlclient/mixin/GuiGraphicsMixin.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2021-2023 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.mixin;
 
 import java.util.List;

--- a/1.20/src/main/java/io/github/axolotlclient/mixin/GuiGraphicsMixin.java
+++ b/1.20/src/main/java/io/github/axolotlclient/mixin/GuiGraphicsMixin.java
@@ -22,20 +22,13 @@
 
 package io.github.axolotlclient.mixin;
 
-import java.util.List;
-
 import io.github.axolotlclient.modules.scrollableTooltips.ScrollableTooltips;
 import net.minecraft.client.MinecraftClient;
-import net.minecraft.client.font.TextRenderer;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
-import net.minecraft.client.gui.tooltip.TooltipComponent;
-import net.minecraft.client.gui.tooltip.TooltipPositioner;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.ModifyVariable;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(GuiGraphics.class)
 public class GuiGraphicsMixin {

--- a/1.20/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.20/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -42,19 +42,6 @@ import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 @Mixin(Screen.class)
 public abstract class ScreenMixin {
 
-	@ModifyArgs(method = "renderWithTooltip", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/GuiGraphics;drawTooltip(Lnet/minecraft/client/font/TextRenderer;Ljava/util/List;Lnet/minecraft/client/gui/tooltip/TooltipPositioner;II)V"))
-	public void axolotlclient$modifyTooltipPosition(Args args) {
-		if (ScrollableTooltips.getInstance().enabled.get()) {
-			if ((MinecraftClient.getInstance().currentScreen instanceof CreativeInventoryScreen)
-				&& ((CreativeInventoryScreen) MinecraftClient.getInstance().currentScreen).isInventoryOpen()) {
-				return;
-			}
-
-			args.set(3, (int) args.get(3) + ScrollableTooltips.getInstance().tooltipOffsetX);
-			args.set(4, (int) args.get(4) + ScrollableTooltips.getInstance().tooltipOffsetY);
-		}
-	}
-
 	@Inject(method = "handleTextClick", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/ClickEvent;getAction()Lnet/minecraft/text/ClickEvent$Action;", ordinal = 0), cancellable = true)
 	public void axolotlclient$customClickEvents(Style style, CallbackInfoReturnable<Boolean> cir) {
 		ClickEvent event = style.getClickEvent();

--- a/1.20/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.20/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -24,20 +24,15 @@ package io.github.axolotlclient.mixin;
 
 import io.github.axolotlclient.modules.blur.MenuBlur;
 import io.github.axolotlclient.modules.screenshotUtils.ScreenshotUtils;
-import io.github.axolotlclient.modules.scrollableTooltips.ScrollableTooltips;
-import net.minecraft.client.MinecraftClient;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.client.gui.screen.Screen;
-import net.minecraft.client.gui.screen.ingame.CreativeInventoryScreen;
 import net.minecraft.text.ClickEvent;
 import net.minecraft.text.Style;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.ModifyArgs;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-import org.spongepowered.asm.mixin.injection.invoke.arg.Args;
 
 @Mixin(Screen.class)
 public abstract class ScreenMixin {

--- a/1.20/src/main/resources/axolotlclient.mixins.json
+++ b/1.20/src/main/resources/axolotlclient.mixins.json
@@ -23,6 +23,7 @@
 		"EntityRendererMixin",
 		"GameMenuScreenMixin",
 		"GameRendererMixin",
+		"GuiGraphicsMixin",
 		"HandledScreenMixin",
 		"InGameHudMixin",
 		"InGameOverlayRendererMixin",

--- a/1.8.9/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/mixin/ScreenMixin.java
@@ -57,9 +57,11 @@ public abstract class ScreenMixin {
 				return;
 			}
 
+			int y = args.get(2);
 			ScrollableTooltips.getInstance().onRenderTooltip();
+			ScrollableTooltips.getInstance().alignToScreenBottom(args.get(0), y);
 			args.set(1, (int) args.get(1) + ScrollableTooltips.getInstance().tooltipOffsetX);
-			args.set(2, (int) args.get(2) + ScrollableTooltips.getInstance().tooltipOffsetY);
+			args.set(2, y + ScrollableTooltips.getInstance().tooltipOffsetY);
 		}
 	}
 

--- a/1.8.9/src/main/java/io/github/axolotlclient/modules/scrollableTooltips/ScrollableTooltips.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/modules/scrollableTooltips/ScrollableTooltips.java
@@ -109,9 +109,9 @@ public class ScrollableTooltips extends AbstractModule {
 
 	public void alignToScreenBottom(List<String> tooltip, int y){
 		if(alignToBottom.get() && !alignedToBottom) {
-			int height = tooltip.size() * 10;
+			int height = tooltip.size() * 10 - 4;
 
-			if(height + y - 4 > Util.getWindow().getHeight()){
+			if(height + y > Util.getWindow().getHeight()){
 				tooltipOffsetY = Util.getWindow().getHeight() - y - height;
 			}
 

--- a/1.8.9/src/main/java/io/github/axolotlclient/modules/scrollableTooltips/ScrollableTooltips.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/modules/scrollableTooltips/ScrollableTooltips.java
@@ -22,11 +22,14 @@
 
 package io.github.axolotlclient.modules.scrollableTooltips;
 
+import java.util.List;
+
 import io.github.axolotlclient.AxolotlClient;
 import io.github.axolotlclient.AxolotlClientConfig.options.BooleanOption;
 import io.github.axolotlclient.AxolotlClientConfig.options.IntegerOption;
 import io.github.axolotlclient.AxolotlClientConfig.options.OptionCategory;
 import io.github.axolotlclient.modules.AbstractModule;
+import io.github.axolotlclient.util.Util;
 import net.minecraft.client.gui.screen.Screen;
 import org.lwjgl.input.Mouse;
 
@@ -38,9 +41,12 @@ public class ScrollableTooltips extends AbstractModule {
 		true);
 	protected final IntegerOption scrollAmount = new IntegerOption("scrollAmount", 5, 1, 20);
 	protected final BooleanOption inverse = new BooleanOption("inverse", false);
+	private final BooleanOption alignToBottom = new BooleanOption("alignToBottom", false);
 	private final OptionCategory category = new OptionCategory("scrollableTooltips");
 	public int tooltipOffsetX;
 	public int tooltipOffsetY;
+
+	private boolean alignedToBottom;
 
 	public static ScrollableTooltips getInstance() {
 		return instance;
@@ -52,12 +58,14 @@ public class ScrollableTooltips extends AbstractModule {
 		category.add(enableShiftHorizontalScroll);
 		category.add(scrollAmount);
 		category.add(inverse);
+		category.add(alignToBottom);
 
 		AxolotlClient.CONFIG.rendering.addSubCategory(category);
 	}
 
 	public void onRenderTooltip() {
 		if (enabled.get()) {
+
 			int i = Mouse.getDWheel();
 			if (i != 0) {
 				if (i < 0) {
@@ -95,6 +103,19 @@ public class ScrollableTooltips extends AbstractModule {
 	}
 
 	public void resetScroll() {
+		alignedToBottom = false;
 		tooltipOffsetY = tooltipOffsetX = 0;
+	}
+
+	public void alignToScreenBottom(List<String> tooltip, int y){
+		if(alignToBottom.get() && !alignedToBottom) {
+			int height = tooltip.size() * 10;
+
+			if(height + y - 4 > Util.getWindow().getHeight()){
+				tooltipOffsetY = Util.getWindow().getHeight() - y - height;
+			}
+
+			alignedToBottom = true;
+		}
 	}
 }

--- a/1.8.9/src/main/resources/assets/axolotlclient/lang/en_us.json
+++ b/1.8.9/src/main/resources/assets/axolotlclient/lang/en_us.json
@@ -14,5 +14,5 @@
 	"scrollbarColor": "Scrollbar Color",
 	"unfocusedFPS": "Unfocused FPS",
 	"unfocusedVolumeMultiplier": "Unfocused Volume Multiplier",
-	"alignToBottom": "Align to Bottom Screen edge"
+	"alignToBottom": "Align to Bottom Screen Edge"
 }

--- a/1.8.9/src/main/resources/assets/axolotlclient/lang/en_us.json
+++ b/1.8.9/src/main/resources/assets/axolotlclient/lang/en_us.json
@@ -13,5 +13,6 @@
 	"runGCOnUnfocus": "Run GC on Unfocus",
 	"scrollbarColor": "Scrollbar Color",
 	"unfocusedFPS": "Unfocused FPS",
-	"unfocusedVolumeMultiplier": "Unfocused Volume Multiplier"
+	"unfocusedVolumeMultiplier": "Unfocused Volume Multiplier",
+	"alignToBottom": "Align to Bottom Screen edge"
 }


### PR DESCRIPTION
- all other versions do this by themselves already
- fix 1.20.1 entirely, it didn't work at all before
- enable tooltip overflow in versions >1.19.2 (it was relatively easy to add)

Related suggestion: https://discord.com/channels/872856682567454720/1129855811569590393