### PR TITLE
Fix crashes when opening tablist in bedwars

### DIFF
--- a/1.16.5/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
+++ b/1.16.5/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
@@ -250,7 +250,7 @@ public abstract class PlayerListHudMixin {
 	}
 
 	@Inject(method = "getPlayerName", at = @At("HEAD"), cancellable = true)
-	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<String> cir) {
+	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<Text> cir) {
 		if (!BedwarsMod.getInstance().isEnabled()) {
 			return;
 		}
@@ -262,7 +262,7 @@ public abstract class PlayerListHudMixin {
 		if (player == null) {
 			return;
 		}
-		cir.setReturnValue(player.getTabListDisplay());
+		cir.setReturnValue(Text.of(player.getTabListDisplay()));
 	}
 
 	@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/google/common/collect/Ordering;sortedCopy(Ljava/lang/Iterable;)Ljava/util/List;", remap = false))

--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
@@ -252,7 +252,7 @@ public abstract class PlayerListHudMixin {
 	}
 
 	@Inject(method = "getPlayerName", at = @At("HEAD"), cancellable = true)
-	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<String> cir) {
+	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<Text> cir) {
 		if (!BedwarsMod.getInstance().isEnabled()) {
 			return;
 		}
@@ -264,7 +264,7 @@ public abstract class PlayerListHudMixin {
 		if (player == null) {
 			return;
 		}
-		cir.setReturnValue(player.getTabListDisplay());
+		cir.setReturnValue(Text.of(player.getTabListDisplay()));
 	}
 
 	@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/google/common/collect/Ordering;sortedCopy(Ljava/lang/Iterable;)Ljava/util/List;", remap = false))

--- a/1.19.2/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
+++ b/1.19.2/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
@@ -246,7 +246,7 @@ public abstract class PlayerListHudMixin {
 	}
 
 	@Inject(method = "getPlayerName", at = @At("HEAD"), cancellable = true)
-	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<String> cir) {
+	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<Text> cir) {
 		if (!BedwarsMod.getInstance().isEnabled()) {
 			return;
 		}
@@ -258,7 +258,7 @@ public abstract class PlayerListHudMixin {
 		if (player == null) {
 			return;
 		}
-		cir.setReturnValue(player.getTabListDisplay());
+		cir.setReturnValue(Text.of(player.getTabListDisplay()));
 	}
 
 	@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Lcom/google/common/collect/Ordering;sortedCopy(Ljava/lang/Iterable;)Ljava/util/List;", remap = false))

--- a/1.19.3/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
+++ b/1.19.3/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
@@ -245,7 +245,7 @@ public abstract class PlayerListHudMixin {
 	}
 
 	@Inject(method = "getPlayerName", at = @At("HEAD"), cancellable = true)
-	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<String> cir) {
+	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<Text> cir) {
 		if (!BedwarsMod.getInstance().isEnabled()) {
 			return;
 		}
@@ -257,7 +257,7 @@ public abstract class PlayerListHudMixin {
 		if (player == null) {
 			return;
 		}
-		cir.setReturnValue(player.getTabListDisplay());
+		cir.setReturnValue(Text.of(player.getTabListDisplay()));
 	}
 
 	@ModifyVariable(method = "render", at = @At(value = "INVOKE_ASSIGN", target = "Ljava/util/stream/Stream;toList()Ljava/util/List;", remap = false))

--- a/1.19.4/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
+++ b/1.19.4/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
@@ -246,7 +246,7 @@ public abstract class PlayerListHudMixin {
 	}
 
 	@Inject(method = "getPlayerName", at = @At("HEAD"), cancellable = true)
-	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<String> cir) {
+	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<Text> cir) {
 		if (!BedwarsMod.getInstance().isEnabled()) {
 			return;
 		}
@@ -258,10 +258,10 @@ public abstract class PlayerListHudMixin {
 		if (player == null) {
 			return;
 		}
-		cir.setReturnValue(player.getTabListDisplay());
+		cir.setReturnValue(Text.of(player.getTabListDisplay()));
 	}
 
-	@ModifyVariable(method = "render", at = @At(value = "STORE"), ordinal = 1)
+	@ModifyVariable(method = "render", at = @At(value = "STORE"), ordinal = 0)
 	public List<PlayerListEntry> axolotlclient$overrideSortedPlayers(List<PlayerListEntry> original) {
 		if (!BedwarsMod.getInstance().inGame()) {
 			return original;

--- a/1.20/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
+++ b/1.20/src/main/java/io/github/axolotlclient/mixin/PlayerListHudMixin.java
@@ -244,7 +244,7 @@ public abstract class PlayerListHudMixin {
 	}
 
 	@Inject(method = "getPlayerName", at = @At("HEAD"), cancellable = true)
-	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<String> cir) {
+	public void axolotlclient$getPlayerName(PlayerListEntry playerEntry, CallbackInfoReturnable<Text> cir) {
 		if (!BedwarsMod.getInstance().isEnabled()) {
 			return;
 		}
@@ -256,7 +256,7 @@ public abstract class PlayerListHudMixin {
 		if (player == null) {
 			return;
 		}
-		cir.setReturnValue(player.getTabListDisplay());
+		cir.setReturnValue(Text.of(player.getTabListDisplay()));
 	}
 
 	@ModifyVariable(method = "render", at = @At(value = "STORE"), ordinal = 0)


### PR DESCRIPTION
Every time I opened the tablist in Bedwars on a version that was not 1.8.9 the game crashed.

The main issues is that `getPlayerName` wants a return type of `Text` instead of `String`.

For 1.19.4, there was a different crash (also when opening the tablist) at the player list variable modification in the render function. Changing the ordinal to 0 (the same as 1.20) appears to fix the crash, but I'm not sure how to verify that the change didn't cause anything else to break.