### PR TITLE
Fix the particle crash properly

### DIFF
--- a/1.16.5/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.16.5/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -86,12 +86,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType<?> type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}

--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -86,12 +86,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType<?> type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}

--- a/1.19.2/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.19.2/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -86,12 +86,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType<?> type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}

--- a/1.19.3/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.19.3/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -86,12 +86,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType<?> type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}

--- a/1.19.4/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.19.4/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -86,12 +86,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType<?> type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}

--- a/1.20/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.20/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -86,12 +86,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType<?> type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setColorAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}

--- a/1.8.9/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -84,12 +84,15 @@ public class Particles extends AbstractModule {
 
 	public void applyOptions(Particle particle) {
 		if (enabled.get() && particleMap.containsKey(particle)) {
-			HashMap<String, Option<?>> options = particleOptions.get(particleMap.get(particle));
+			ParticleType type = particleMap.get(particle);
+			if (particleOptions.containsKey(type)) {
+				HashMap<String, Option<?>> options = particleOptions.get(type);
 
-			if (((BooleanOption) options.get("customColor")).get()) {
-				Color color = ((ColorOption) options.get("color")).get();
-				particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
-				((ParticleAccessor) particle).setAlpha(color.getAlpha() / 255F);
+				if (((BooleanOption) options.get("customColor")).get()) {
+					Color color = ((ColorOption) options.get("color")).get();
+					particle.setColor(color.getRed() / 255F, color.getGreen() / 255F, color.getBlue() / 255F);
+					((ParticleAccessor) particle).setAlpha(color.getAlpha() / 255F);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Some time ago I reported a bug (#83) where there was a crash due to a HashMap not containing some data that was expected to be there. You fixed it partially, but then I got a similar error few more times, so here is a proper fix for that.