### PR TITLE
Disable freelook on MCC island

### DIFF
--- a/1.19.4/src/main/java/io/github/axolotlclient/util/FeatureDisabler.java
+++ b/1.19.4/src/main/java/io/github/axolotlclient/util/FeatureDisabler.java
@@ -62,7 +62,7 @@ public class FeatureDisabler {
 	public static void init() {
 		setServers(AxolotlClient.CONFIG.fullBright, NONE, "gommehd");
 		setServers(AxolotlClient.CONFIG.lowFire, NONE, "gommehd");
-		setServers(Freelook.getInstance().enabled, () -> Freelook.getInstance().needsDisabling(), "hypixel", "mineplex", "gommehd", "nucleoid");
+		setServers(Freelook.getInstance().enabled, () -> Freelook.getInstance().needsDisabling(), "hypixel", "mineplex", "gommehd", "nucleoid", "mccisland");
 		setServers(((ToggleSprintHud) HudManager.getInstance().get(ToggleSprintHud.ID)).toggleSneak, NONE, "hypixel");
 
 		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {

--- a/1.20/src/main/java/io/github/axolotlclient/util/FeatureDisabler.java
+++ b/1.20/src/main/java/io/github/axolotlclient/util/FeatureDisabler.java
@@ -62,7 +62,7 @@ public class FeatureDisabler {
 	public static void init() {
 		setServers(AxolotlClient.CONFIG.fullBright, NONE, "gommehd");
 		setServers(AxolotlClient.CONFIG.lowFire, NONE, "gommehd");
-		setServers(Freelook.getInstance().enabled, () -> Freelook.getInstance().needsDisabling(), "hypixel", "mineplex", "gommehd", "nucleoid");
+		setServers(Freelook.getInstance().enabled, () -> Freelook.getInstance().needsDisabling(), "hypixel", "mineplex", "gommehd", "nucleoid", "mccisland");
 		setServers(((ToggleSprintHud) HudManager.getInstance().get(ToggleSprintHud.ID)).toggleSneak, NONE, "hypixel");
 
 		ClientPlayConnectionEvents.JOIN.register((handler, sender, client) -> {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -146,3 +146,4 @@
 
 - add more Zoom keybinds
 - add option(s) to remove certain messages on hypixel (join, mystery box)
+- Removed freelook on MCC island (#118 )


### PR DESCRIPTION
i think this syntax works fro dissableing freelook on play.mccisland.net

> ❌ Disallowed Modifications

The general rule of thumb for any mod is that if it will provide a significant advantage in one or more of our games, then it won’t be allowed on the server, such as (but not limited to):

    Hacking clients
        X-Ray
        Freecam
    Inventory Walk
    Other Player's Statuses
    Minimaps
    TNT Timer
    Better F5 (Allowing you to manipulate your camera whilst your movement remains static)
    World Downloaders

> These mods must not change block properties (e.g. make non-transparent blocks transparent to see through walls) or alter the player's POV (e.g. allowing them to see around or over objects they normally wouldn't be able to, such as freecam or perspective mods).


https://mcchampionship.com/help/mods/