### PR TITLE
Fix account switcher list always showing no accounts

### DIFF
--- a/1.20/src/main/java/io/github/axolotlclient/modules/auth/AccountsScreen.java
+++ b/1.20/src/main/java/io/github/axolotlclient/modules/auth/AccountsScreen.java
@@ -43,9 +43,9 @@ public class AccountsScreen extends Screen {
 
 	@Override
 	public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		super.render(graphics, mouseX, mouseY, delta);
 		this.accountsListWidget.render(graphics, mouseX, mouseY, delta);
 		graphics.drawCenteredShadowedText(this.textRenderer, this.title, this.width / 2, 20, 16777215);
-		super.render(graphics, mouseX, mouseY, delta);
 	}
 
 	@Override


### PR DESCRIPTION
Since 1.20.2 the account switcher list has always appeared empty because `AccountsScreen` renders last and ends up on top of the list. This changes the order so that the screen is rendered first.