### PR TITLE
Use WeakHashMap for particle type cache

### DIFF
--- a/1.16.5/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.16.5/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -41,7 +41,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType<?>, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType<?>> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType<?>> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);

--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -41,7 +41,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType<?>, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType<?>> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType<?>> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);

--- a/1.19.2/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.19.2/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -41,7 +41,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType<?>, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType<?>> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType<?>> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);

--- a/1.19.3/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.19.3/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -41,7 +41,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType<?>, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType<?>> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType<?>> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);

--- a/1.19.4/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.19.4/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -41,7 +41,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType<?>, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType<?>> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType<?>> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);

--- a/1.20/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.20/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -41,7 +41,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType<?>, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType<?>> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType<?>> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);

--- a/1.8.9/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/modules/particles/Particles.java
@@ -40,7 +40,7 @@ public class Particles extends AbstractModule {
 	private static final Particles Instance = new Particles();
 
 	public final HashMap<ParticleType, HashMap<String, Option<?>>> particleOptions = new HashMap<>();
-	public final HashMap<Particle, ParticleType> particleMap = new HashMap<>();
+	public final WeakHashMap<Particle, ParticleType> particleMap = new WeakHashMap<>();
 
 	private final OptionCategory cat = new OptionCategory("particles");
 	private final BooleanOption enabled = new BooleanOption("enabled", false);


### PR DESCRIPTION
I noticed a slow memory leak and the cause was that `particleMap` grows infinitely and entries are never removed. It appears that `ParticleManagerMixin` never actually removes particles, `particle.isAlive()` was always true for me. Since this is just a cache for a particle instance's type, I changed it to a `WeakHashMap` since the cache should never hold the only reference to a particle.

With this change the map will now shrink as the particles are GC'd and the memory leak is gone.