### PR TITLE
Fix badge rendering

### DIFF
--- a/1.8.9/src/main/java/io/github/axolotlclient/util/BadgeRenderer.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/util/BadgeRenderer.java
@@ -28,38 +28,45 @@ import io.github.axolotlclient.api.requests.UserRequest;
 import io.github.axolotlclient.modules.hypixel.nickhider.NickHider;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiElement;
+import net.minecraft.client.render.TextRenderer;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.living.player.PlayerEntity;
 
 public class BadgeRenderer {
 	public static void renderNametagBadge(Entity entity) {
-		if (entity instanceof PlayerEntity && !entity.isSneaking()) {
-			if (AxolotlClient.CONFIG.showBadges.get() && UserRequest.getOnline(entity.getUuid().toString())) {
-				GlStateManager.alphaFunc(516, 0.1F);
-				GlStateManager.enableDepthTest();
-				GlStateManager.enableAlphaTest();
-				Minecraft.getInstance().getTextureManager().bind(AxolotlClient.badgeIcon);
-
-				int x = -(Minecraft.getInstance().textRenderer
-					.getWidth(entity.getUuid() == Minecraft.getInstance().player.getUuid()
-						? (NickHider.getInstance().hideOwnName.get() ? NickHider.getInstance().hiddenNameSelf.get()
-						: entity.getDisplayName().getFormattedString())
-						: (NickHider.getInstance().hideOtherNames.get() ? NickHider.getInstance().hiddenNameOthers.get()
-						: entity.getDisplayName().getFormattedString()))
-					/ 2
-					+ (AxolotlClient.CONFIG.customBadge.get() ? Minecraft.getInstance().textRenderer
-					.getWidth(" " + AxolotlClient.CONFIG.badgeText.get()) : 10));
-
-				GlStateManager.color4f(1, 1, 1, 1);
-
-				if (AxolotlClient.CONFIG.customBadge.get())
-					Minecraft.getInstance().textRenderer.draw(AxolotlClient.CONFIG.badgeText.get(), x, 0, -1,
-						AxolotlClient.CONFIG.useShadows.get());
-				else {
-					GuiElement.drawTexture(x, 0, 0, 0, 8, 8, 8, 8);
-				}
-				GlStateManager.disableDepthTest();
-			}
+		if (!(entity instanceof PlayerEntity) || entity.isSneaking()) {
+			return;
 		}
+
+		if (!AxolotlClient.CONFIG.showBadges.get() || !UserRequest.getOnline(entity.getUuid().toString())) {
+			return;
+		}
+
+		TextRenderer textRenderer = Minecraft.getInstance().textRenderer;
+
+		GlStateManager.enableDepthTest();
+		GlStateManager.depthMask(true);
+
+		int x = -(textRenderer
+			.getWidth(entity.getUuid() == Minecraft.getInstance().player.getUuid()
+				? (NickHider.getInstance().hideOwnName.get() ? NickHider.getInstance().hiddenNameSelf.get()
+				: entity.getDisplayName().getFormattedString())
+				: (NickHider.getInstance().hideOtherNames.get() ? NickHider.getInstance().hiddenNameOthers.get()
+				: entity.getDisplayName().getFormattedString()))
+			/ 2
+			+ (AxolotlClient.CONFIG.customBadge.get() ? textRenderer
+			.getWidth(" " + AxolotlClient.CONFIG.badgeText.get()) : 10));
+
+		GlStateManager.color4f(1, 1, 1, 1);
+
+		if (AxolotlClient.CONFIG.customBadge.get())
+			textRenderer.draw(AxolotlClient.CONFIG.badgeText.get(), x, 0, -1, AxolotlClient.CONFIG.useShadows.get());
+		else {
+			GlStateManager.alphaFunc(516, 0.1F);
+			GlStateManager.enableAlphaTest();
+			Minecraft.getInstance().getTextureManager().bind(AxolotlClient.badgeIcon);
+			GuiElement.drawTexture(x, 0, 0, 0, 8, 8, 8, 8);
+		}
+		GlStateManager.disableDepthTest();
 	}
 }


### PR DESCRIPTION
The badge renders behind some objects in the world, which is a bug. Vanilla does `GlStateManager.depthMask(true);` before rendering the name tag. This seems to fix the bug. Also refactor to early return to prevent nesting.

Some other GL calls don't seem necessary for custom badge, so moved it into the else branch.