### PR TITLE
fix: crash with entities that arent in the level

### DIFF
--- a/1.21.7/src/main/java/io/github/axolotlclient/mixin/PlayerEntityRendererMixin.java
+++ b/1.21.7/src/main/java/io/github/axolotlclient/mixin/PlayerEntityRendererMixin.java
@@ -45,9 +45,9 @@ public abstract class PlayerEntityRendererMixin {
 	@WrapOperation(method = "renderNameTag(Lnet/minecraft/client/renderer/entity/state/PlayerRenderState;Lnet/minecraft/network/chat/Component;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V",
 		at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/entity/LivingEntityRenderer;renderNameTag(Lnet/minecraft/client/renderer/entity/state/EntityRenderState;Lnet/minecraft/network/chat/Component;Lcom/mojang/blaze3d/vertex/PoseStack;Lnet/minecraft/client/renderer/MultiBufferSource;I)V"))
 	private void axolotlclient$modifiyName(PlayerRenderer instance, EntityRenderState entityRenderState, Component component, PoseStack poseStack, MultiBufferSource source, int i, Operation<Void> original, @Local(argsOnly = true) PlayerRenderState state) {
-		if (AxolotlClient.CONFIG != null) {
-			Level level = Minecraft.getInstance().level;
-			Entity player = level.getEntity(state.id);
+		Level level = Minecraft.getInstance().level;
+		Entity player = level.getEntity(state.id);
+		if (AxolotlClient.CONFIG != null && player != null) {
 			boolean self = player.getUUID() == Minecraft.getInstance().player.getUUID();
 			if (self && NickHider.getInstance().hideOwnName.get()) {
 				component = NickHider.getInstance().editComponent(component, player.getName().getString(), NickHider.getInstance().hiddenNameSelf.get());


### PR DESCRIPTION
Fixes a crash with mods that render custom players (that arent in the level) on screen.
In SkyBlock Pv, we create a custom players.

(this would also be good as a .5 release)

<details>
<summary>Crash Log</summary>

---- Minecraft Crash Report ----
// There are four lights!

Time: 2025-07-04 00:51:49
Description: Rendering entity in world

java.lang.NullPointerException: Cannot invoke "net.minecraft.class_1297.method_5667()" because "player" is null
	at knot//net.minecraft.class_1007.wrapOperation$zfd000$axolotlclient$modifiyName(class_1007.java:551)
	at knot//net.minecraft.class_1007.wrapOperation$zfd000$axolotlclient$modifiyName$mixinextras$bridge$64(class_1007.java)
	at knot//net.minecraft.class_1007.mixinextras$bridge$wrapOperation$zfd000$axolotlclient$modifiyName$mixinextras$bridge$64$68(class_1007.java)
	at knot//net.minecraft.class_1007.mdb3eb6d$skyblockpv$lambda$nameShader$1$2(class_1007.java:3064)
	at knot//me.owdding.skyblockpv.utils.render.RenderUtils.pushPopTextShader(RenderUtils.kt:105)
	at knot//net.minecraft.class_1007.wrapOperation$egd000$skyblockpv$nameShader(class_1007.java:3063)
	at knot//net.minecraft.class_1007.method_4213(class_1007.java:159)
	at knot//net.minecraft.class_1007.method_3926(class_1007.java:55)
	at knot//net.minecraft.class_897.method_3936(class_897.java:117)
	at knot//net.minecraft.class_922.method_4054(class_922.java:122)
	at knot//net.minecraft.class_922.method_3936(class_922.java:42)
	at knot//net.minecraft.class_898.method_68834(class_898.java:203)
	at knot//net.minecraft.class_898.method_3954(class_898.java:178)
	at knot//net.minecraft.class_898.method_62424(class_898.java:160)
	at knot//net.minecraft.class_490.method_64045(class_490.java:152)
	at knot//net.minecraft.class_332.method_64039(class_332.java:679)
	at knot//net.minecraft.class_490.method_48472(class_490.java:151)
	at knot//me.owdding.lib.displays.Displays$entity$1.render(Displays.kt:462)
	at knot//me.owdding.lib.displays.Display$DefaultImpls.render(Display.kt:15)
	at knot//me.owdding.lib.displays.Displays$entity$1.render(Displays.kt:428)
	at knot//me.owdding.lib.displays.Display$DefaultImpls.render$default(Display.kt:13)
	at knot//me.owdding.skyblockpv.screens.tabs.MainScreen.getPlayerDisplay$lambda$28(MainScreen.kt:232)
	at knot//me.owdding.lib.displays.DisplayWidget.method_48579(DisplayWidget.kt:21)
	at knot//net.minecraft.class_339.method_25394(class_339.java:66)
	at knot//net.minecraft.class_437.method_25394(class_437.java:124)
	at knot//com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen.actuallyRender(BaseCursorScreen.java:44)
	at knot//com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen.method_25394(BaseCursorScreen.java:25)
	at knot//net.minecraft.class_437.mixinextras$bridge$method_25394$142(class_437.java)
	at knot//net.minecraft.class_437.wrapOperation$eaf000$skyblock-api$renderBefore(class_437.java:3182)
	at knot//net.minecraft.class_437.method_47413(class_437.java:113)
	at knot//net.minecraft.class_757.mixinextras$bridge$method_47413$107(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$cbf000$fabric-screen-api-v1$onRenderScreen(class_757.java:1915)
	at knot//net.minecraft.class_757.method_3192(class_757.java:572)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1353)
	at knot//net.minecraft.class_310.method_1514(class_310.java:936)
	at knot//net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)


A detailed walkthrough of the error, its code path and all known details is as follows:
---------------------------------------------------------------------------------------

-- Head --
Thread: Render thread
Stacktrace:
	at knot//net.minecraft.class_1007.wrapOperation$zfd000$axolotlclient$modifiyName(class_1007.java:551)
	at knot//net.minecraft.class_1007.wrapOperation$zfd000$axolotlclient$modifiyName$mixinextras$bridge$64(class_1007.java)
	at knot//net.minecraft.class_1007.mixinextras$bridge$wrapOperation$zfd000$axolotlclient$modifiyName$mixinextras$bridge$64$68(class_1007.java)
	at knot//net.minecraft.class_1007.mdb3eb6d$skyblockpv$lambda$nameShader$1$2(class_1007.java:3064)
	at knot//me.owdding.skyblockpv.utils.render.RenderUtils.pushPopTextShader(RenderUtils.kt:105)
	at knot//net.minecraft.class_1007.wrapOperation$egd000$skyblockpv$nameShader(class_1007.java:3063)
	at knot//net.minecraft.class_1007.method_4213(class_1007.java:159)
	at knot//net.minecraft.class_1007.method_3926(class_1007.java:55)
	at knot//net.minecraft.class_897.method_3936(class_897.java:117)
	at knot//net.minecraft.class_922.method_4054(class_922.java:122)

-- EntityRenderState being rendered --
Details:
	EntityRenderState: net.minecraft.class_10055
	Entity's Exact location: -2.50, 71.00, -69.50
Stacktrace:
	at knot//net.minecraft.class_898.method_68834(class_898.java:203)
	at knot//net.minecraft.class_898.method_3954(class_898.java:178)
	at knot//net.minecraft.class_898.method_62424(class_898.java:160)
	at knot//net.minecraft.class_490.method_64045(class_490.java:152)
	at knot//net.minecraft.class_332.method_64039(class_332.java:679)
	at knot//net.minecraft.class_490.method_48472(class_490.java:151)
	at knot//me.owdding.lib.displays.Displays$entity$1.render(Displays.kt:462)
	at knot//me.owdding.lib.displays.Display$DefaultImpls.render(Display.kt:15)
	at knot//me.owdding.lib.displays.Displays$entity$1.render(Displays.kt:428)
	at knot//me.owdding.lib.displays.Display$DefaultImpls.render$default(Display.kt:13)
	at knot//me.owdding.skyblockpv.screens.tabs.MainScreen.getPlayerDisplay$lambda$28(MainScreen.kt:232)
	at knot//me.owdding.lib.displays.DisplayWidget.method_48579(DisplayWidget.kt:21)
	at knot//net.minecraft.class_339.method_25394(class_339.java:66)
	at knot//net.minecraft.class_437.method_25394(class_437.java:124)
	at knot//com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen.actuallyRender(BaseCursorScreen.java:44)
	at knot//com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen.method_25394(BaseCursorScreen.java:25)
	at knot//net.minecraft.class_437.mixinextras$bridge$method_25394$142(class_437.java)
	at knot//net.minecraft.class_437.wrapOperation$eaf000$skyblock-api$renderBefore(class_437.java:3182)
	at knot//net.minecraft.class_437.method_47413(class_437.java:113)
	at knot//net.minecraft.class_757.mixinextras$bridge$method_47413$107(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$cbf000$fabric-screen-api-v1$onRenderScreen(class_757.java:1915)
	at knot//net.minecraft.class_757.method_3192(class_757.java:572)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1353)
	at knot//net.minecraft.class_310.method_1514(class_310.java:936)
	at knot//net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)

-- Renderer details --
Details:
	Assigned renderer: net.minecraft.class_1007@3a274fb5
	Location: 0.00,0.00,0.00 - World: (0,0,0), Section: (at 0,0,0 in 0,0,0; chunk contains blocks 0,0,0 to 15,255,15), Region: (0,0; contains chunks 0,0 to 31,31, blocks 0,0,0 to 511,255,511)
Stacktrace:
	at knot//net.minecraft.class_898.method_68829(class_898.java:245)
	at knot//net.minecraft.class_898.method_68834(class_898.java:238)
	at knot//net.minecraft.class_898.method_3954(class_898.java:178)
	at knot//net.minecraft.class_898.method_62424(class_898.java:160)
	at knot//net.minecraft.class_490.method_64045(class_490.java:152)
	at knot//net.minecraft.class_332.method_64039(class_332.java:679)
	at knot//net.minecraft.class_490.method_48472(class_490.java:151)
	at knot//me.owdding.lib.displays.Displays$entity$1.render(Displays.kt:462)
	at knot//me.owdding.lib.displays.Display$DefaultImpls.render(Display.kt:15)
	at knot//me.owdding.lib.displays.Displays$entity$1.render(Displays.kt:428)
	at knot//me.owdding.lib.displays.Display$DefaultImpls.render$default(Display.kt:13)
	at knot//me.owdding.skyblockpv.screens.tabs.MainScreen.getPlayerDisplay$lambda$28(MainScreen.kt:232)
	at knot//me.owdding.lib.displays.DisplayWidget.method_48579(DisplayWidget.kt:21)
	at knot//net.minecraft.class_339.method_25394(class_339.java:66)
	at knot//net.minecraft.class_437.method_25394(class_437.java:124)
	at knot//com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen.actuallyRender(BaseCursorScreen.java:44)
	at knot//com.teamresourceful.resourcefullib.client.screens.BaseCursorScreen.method_25394(BaseCursorScreen.java:25)
	at knot//net.minecraft.class_437.mixinextras$bridge$method_25394$142(class_437.java)
	at knot//net.minecraft.class_437.wrapOperation$eaf000$skyblock-api$renderBefore(class_437.java:3182)
	at knot//net.minecraft.class_437.method_47413(class_437.java:113)
	at knot//net.minecraft.class_757.mixinextras$bridge$method_47413$107(class_757.java)
	at knot//net.minecraft.class_757.wrapOperation$cbf000$fabric-screen-api-v1$onRenderScreen(class_757.java:1915)
	at knot//net.minecraft.class_757.method_3192(class_757.java:572)
	at knot//net.minecraft.class_310.method_1523(class_310.java:1353)
	at knot//net.minecraft.class_310.method_1514(class_310.java:936)
	at knot//net.minecraft.client.main.Main.main(Main.java:265)
	at net.fabricmc.loader.impl.game.minecraft.MinecraftGameProvider.launch(MinecraftGameProvider.java:480)
	at net.fabricmc.loader.impl.launch.knot.Knot.launch(Knot.java:74)
	at net.fabricmc.loader.impl.launch.knot.KnotClient.main(KnotClient.java:23)

-- Entity being rendered --
Details:
	Entity Type: minecraft:player (me.owdding.skyblockpv.utils.FakePlayer)
	Entity ID: 3237
	Entity Name: PhuriKukri
	Entity's Exact location: -2.50, 71.00, -69.50
	Entity's Block location: World: (-3,71,-70), Section: (at 13,7,10 in -1,4,-5; chunk contains blocks -16,0,-80 to -1,255,-65), Region: (-1,-1; contains chunks -32,-32 to -1,-1, blocks -512,0,-512 to -1,255,-1)
	Entity's Momentum: 0.00, 0.00, 0.00
	Entity's Passengers: []
	Entity's Vehicle: null

-- Screen render details --
Details:
	Screen name: me.owdding.skyblockpv.screens.tabs.MainScreen
	Mouse location: Scaled: (256.867188, 98.000000). Absolute: (770.000000, 294.000000)
	Screen size: Scaled: (427, 240). Absolute: (1280, 720). Scale factor of 3.000000

</details>