### PR TITLE
Config profiles

### DIFF
--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
@@ -35,6 +35,7 @@ import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.*;
 import io.github.axolotlclient.AxolotlClientConfigCommon;
 import io.github.axolotlclient.config.screen.CreditsScreen;
+import io.github.axolotlclient.config.screen.ProfilesScreen;
 import io.github.axolotlclient.mixin.OverlayTextureAccessor;
 import io.github.axolotlclient.util.options.ForceableBooleanOption;
 import io.github.axolotlclient.util.options.GenericOption;
@@ -186,6 +187,9 @@ public class AxolotlClientConfig extends AxolotlClientConfigCommon {
 		rendering.add(noRain);
 
 		hidden.add(creditsBGM, someNiceBackground);
+
+		general.add(new GenericOption("profiles.title", "profiles.configure", () ->
+			MinecraftClient.getInstance().openScreen(new ProfilesScreen(MinecraftClient.getInstance().currentScreen))), false);
 
 		var toggleFullbright = new KeyBinding("toggle_fullbright", -1, "category.axolotlclient");
 		KeyBindingHelper.registerKeyBinding(toggleFullbright);

--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.screen;
 
 import java.util.List;
@@ -106,9 +128,8 @@ public class ProfilesScreen extends Screen {
 				this.profile = profile;
 				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, LiteralText.EMPTY);
 				profileName.setText(profile.name());
-				loadButton = new ButtonWidget(0, 0, 50, 20, LOAD_BUTTON_TITLE, btn -> {
-					Profiles.getInstance().switchTo(profile);
-				});
+				loadButton = new ButtonWidget(0, 0, 50, 20, LOAD_BUTTON_TITLE, btn ->
+					Profiles.getInstance().switchTo(profile));
 				duplicateButton = new ButtonWidget(0, 0, 50, 20, DUPLICATE_BUTTON_TITLE, b -> {
 					var dup = Profiles.getInstance().duplicate(profile);
 					double d = (double) Math.max(0, getMaxPosition() - (bottom - top - 4)) - ProfilesList.this.getScrollAmount();

--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,0 +1,186 @@
+package io.github.axolotlclient.config.screen;
+
+import java.util.List;
+
+import io.github.axolotlclient.config.profiles.Profiles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.screen.ScreenTexts;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+
+public class ProfilesScreen extends Screen {
+
+	private final Screen parent;
+
+	public ProfilesScreen(Screen parent) {
+		super(new TranslatableText("profiles.configure.list"));
+		this.parent = parent;
+	}
+
+	@Override
+	public void render(MatrixStack graphics, int mouseX, int mouseY, float delta) {
+		renderBackground(graphics);
+		super.render(graphics, mouseX, mouseY, delta);
+		drawCenteredText(graphics, textRenderer, getTitle(), width / 2, 33 / 2 - textRenderer.fontHeight / 2, -1);
+	}
+
+	@Override
+	protected void init() {
+		addChild(new ProfilesList(client, width, height, 33, height - 33, 25));
+
+		addButton(new ButtonWidget(width / 2 - 75, height - 33 / 2 - 10, 150, 20, ScreenTexts.BACK, btn -> onClose()));
+	}
+
+	@Override
+	public void onClose() {
+		Profiles.getInstance().saveProfiles();
+		client.openScreen(parent);
+	}
+
+	public class ProfilesList extends ElementListWidget<ProfilesList.Entry> {
+		private static final Entry SPACER = new SpacerEntry();
+		private final Entry ADD = new NewEntry();
+
+		public ProfilesList(MinecraftClient minecraft, int width, int height, int top, int bottom, int itemHeight) {
+			super(minecraft, width, height, top, bottom, itemHeight);
+			reload();
+		}
+
+		public void reload() {
+			clearEntries();
+			Profiles.getInstance().iterateAvailable(p -> addEntry(new ProfileEntry(p)));
+			addEntry(SPACER);
+			addEntry(ADD);
+		}
+
+		@Override
+		public int getRowWidth() {
+			return 340;
+		}
+
+		@Override
+		protected int getScrollbarPositionX() {
+			return getRowLeft() + getRowWidth() + 10;
+		}
+
+		@Environment(EnvType.CLIENT)
+		public abstract static class Entry extends ElementListWidget.Entry<Entry> {
+
+		}
+
+		public static class SpacerEntry extends Entry {
+			@Override
+			public void render(MatrixStack guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of();
+			}
+		}
+
+		@Environment(EnvType.CLIENT)
+		public class ProfileEntry extends Entry {
+			private static final Text CURRENT_TEXT = new TranslatableText("profiles.profile.current");
+			private static final Text LOAD_BUTTON_TITLE = new TranslatableText("profiles.profile.load");
+			private static final Text DUPLICATE_BUTTON_TITLE = new TranslatableText("profiles.profile.duplicate");
+			private static final Text REMOVE_BUTTON_TITLE = new TranslatableText("profiles.profile.remove");
+			private final TextFieldWidget profileName;
+			private final ButtonWidget loadButton;
+			private final ButtonWidget duplicateButton;
+			private final ButtonWidget removeButton;
+			private final Profiles.Profile profile;
+
+			ProfileEntry(Profiles.Profile profile) {
+				this.profile = profile;
+				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, LiteralText.EMPTY);
+				profileName.setText(profile.name());
+				loadButton = new ButtonWidget(0, 0, 50, 20, LOAD_BUTTON_TITLE, btn -> {
+					Profiles.getInstance().switchTo(profile);
+				});
+				duplicateButton = new ButtonWidget(0, 0, 50, 20, DUPLICATE_BUTTON_TITLE, b -> {
+					var dup = Profiles.getInstance().duplicate(profile);
+					double d = (double) Math.max(0, getMaxPosition() - (bottom - top - 4)) - ProfilesList.this.getScrollAmount();
+					ProfilesList.this.children().add(ProfilesList.this.children().indexOf(ProfileEntry.this) + 1, new ProfileEntry(dup));
+					ProfilesList.this.setScrollAmount(Math.max(0, getMaxPosition() - (bottom - top - 4)) - d);
+				});
+
+				this.removeButton = new ButtonWidget(0, 0, 50, 20, REMOVE_BUTTON_TITLE, b -> {
+					removeEntry(this);
+					Profiles.getInstance().remove(profile);
+					setScrollAmount(getScrollAmount());
+				});
+			}
+
+			@Override
+			public void render(MatrixStack guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - removeButton.getWidth() - 4;
+				int j = top - 2;
+				this.removeButton.x = i;
+				removeButton.y = j;
+				this.removeButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				i -= duplicateButton.getWidth();
+				duplicateButton.x = i;
+				duplicateButton.y = j;
+				duplicateButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				boolean current = Profiles.getInstance().getCurrent() == profile;
+				loadButton.setMessage(current ? CURRENT_TEXT : LOAD_BUTTON_TITLE);
+				loadButton.active = !current;
+				i -= loadButton.getWidth();
+				this.loadButton.x = i;
+				loadButton.y = j;
+				this.loadButton.render(guiGraphics, mouseX, mouseY, partialTick);
+				profileName.setWidth(i - left - 4);
+				profileName.x = left;
+				profileName.y = j;
+				profileName.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+		}
+
+		public class NewEntry extends Entry {
+
+			private final ButtonWidget addButton;
+
+			public NewEntry() {
+				this.addButton = new ButtonWidget(0, 0, 150, 20, new TranslatableText("profiles.profile.add"), button -> {
+					int i = ProfilesList.this.children().indexOf(this);
+					ProfilesList.this.children().add(Math.max(i - 1, 0), new ProfileEntry(Profiles.getInstance().newProfile(I18n.translate("profiles.profile.default_new_name"))));
+					Profiles.getInstance().saveProfiles();
+					setScrollAmount(Math.max(0, getMaxPosition() - (bottom - top - 4)));
+				});
+			}
+
+			@Override
+			public void render(MatrixStack guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - width / 2 - 10 - addButton.getWidth() / 2;
+				int j = top - 2;
+				this.addButton.x = i;
+				addButton.y = j;
+				this.addButton.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(addButton);
+			}
+		}
+	}
+}

--- a/1.16_combat-6/src/main/java/io/github/axolotlclient/modules/hud/gui/hud/KeystrokeHud.java
+++ b/1.16_combat-6/src/main/java/io/github/axolotlclient/modules/hud/gui/hud/KeystrokeHud.java
@@ -23,7 +23,6 @@
 package io.github.axolotlclient.modules.hud.gui.hud;
 
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.function.Function;
 import java.util.function.Supplier;
@@ -36,6 +35,7 @@ import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.ColorOption;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.IntegerOption;
 import io.github.axolotlclient.bridge.render.AxoRenderContext;
+import io.github.axolotlclient.config.profiles.ProfileAware;
 import io.github.axolotlclient.mixin.KeyBindAccessor;
 import io.github.axolotlclient.modules.hud.ClickInputTracker;
 import io.github.axolotlclient.modules.hud.gui.keystrokes.KeystrokePositioningScreen;
@@ -71,9 +71,9 @@ import static io.github.axolotlclient.modules.hud.util.DrawUtil.*;
  * @license GPL-3.0
  */
 
-public class KeystrokeHud extends TextHudEntry {
+public class KeystrokeHud extends TextHudEntry implements ProfileAware {
 
-	private static final Path KEYSTROKE_SAVE_FILE = AxolotlClientCommon.resolveConfigFile("keystrokes.json");
+	private static final String KEYSTROKE_SAVE_FILE_NAME = "keystrokes.json";
 	public static final Identifier ID = new Identifier("kronhud", "keystrokehud");
 
 	private final MinecraftClient client = (MinecraftClient) super.client;
@@ -224,6 +224,11 @@ public class KeystrokeHud extends TextHudEntry {
 	@Override
 	public Identifier getId() {
 		return ID;
+	}
+
+	@Override
+	public void reloadConfig() {
+		keystrokes = null;
 	}
 
 	public interface KeystrokeRenderer {
@@ -466,8 +471,9 @@ public class KeystrokeHud extends TextHudEntry {
 
 	public void saveKeystrokes() {
 		try {
-			Files.createDirectories(KEYSTROKE_SAVE_FILE.getParent());
-			Files.writeString(KEYSTROKE_SAVE_FILE, GsonHelper.GSON.toJson(keystrokes.stream().map(Keystroke::serialize).toList()));
+			var path = AxolotlClientCommon.resolveProfileConfigFile(KEYSTROKE_SAVE_FILE_NAME);
+			Files.createDirectories(path.getParent());
+			Files.writeString(path, GsonHelper.GSON.toJson(keystrokes.stream().map(Keystroke::serialize).toList()));
 		} catch (Exception e) {
 			AxolotlClient.LOGGER.warn("Failed to save keystroke configuration!", e);
 		}
@@ -476,8 +482,9 @@ public class KeystrokeHud extends TextHudEntry {
 	@SuppressWarnings("unchecked")
 	public void loadKeystrokes() {
 		try {
-			if (Files.exists(KEYSTROKE_SAVE_FILE)) {
-				List<?> entries = (List<?>) GsonHelper.read(Files.readString(KEYSTROKE_SAVE_FILE));
+			var path = AxolotlClientCommon.resolveProfileConfigFile(KEYSTROKE_SAVE_FILE_NAME);
+			if (Files.exists(path)) {
+				List<?> entries = (List<?>) GsonHelper.read(Files.readString(path));
 				var loaded = entries.stream().map(e -> (Map<String, Object>) e)
 					.map(KeystrokeHud.this::deserializeKey)
 					.toList();

--- a/1.20/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
+++ b/1.20/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
@@ -36,6 +36,7 @@ import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.*;
 import io.github.axolotlclient.AxolotlClientConfigCommon;
 import io.github.axolotlclient.config.screen.CreditsScreen;
+import io.github.axolotlclient.config.screen.ProfilesScreen;
 import io.github.axolotlclient.mixin.OverlayTextureAccessor;
 import io.github.axolotlclient.util.keybinds.KeyBinds;
 import io.github.axolotlclient.util.options.ForceableBooleanOption;
@@ -183,6 +184,9 @@ public class AxolotlClientConfig extends AxolotlClientConfigCommon {
 		rendering.add(noRain);
 
 		hidden.add(creditsBGM, someNiceBackground);
+
+		general.add(new GenericOption("profiles.title", "profiles.configure", () ->
+			MinecraftClient.getInstance().setScreen(new ProfilesScreen(MinecraftClient.getInstance().currentScreen))), false);
 
 		var toggleFullbright = new KeyBind("toggle_fullbright", -1, "category.axolotlclient");
 		KeyBinds.getInstance().registerWithSimpleAction(toggleFullbright, fullBright::toggle);

--- a/1.20/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.20/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,0 +1,208 @@
+package io.github.axolotlclient.config.screen;
+
+import java.util.List;
+
+import io.github.axolotlclient.config.profiles.Profiles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.ButtonWidget;
+import net.minecraft.client.gui.widget.ElementListWidget;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.text.CommonTexts;
+import net.minecraft.text.Text;
+
+public class ProfilesScreen extends Screen {
+
+	private ProfilesList profilesList;
+	private final Screen parent;
+
+	public ProfilesScreen(Screen parent) {
+		super(Text.translatable("profiles.configure.list"));
+		this.parent = parent;
+	}
+
+	@Override
+	public void render(GuiGraphics graphics, int mouseX, int mouseY, float delta) {
+		renderBackground(graphics);
+		super.render(graphics, mouseX, mouseY, delta);
+		graphics.drawCenteredShadowedText(textRenderer, getTitle(), width / 2, 33 / 2 - textRenderer.fontHeight / 2, -1);
+	}
+
+	@Override
+	protected void init() {
+
+		profilesList = addDrawableChild(new ProfilesList(client, width, height, 33, height - 33, 25));
+
+		addDrawableChild(ButtonWidget.builder(CommonTexts.BACK, btn -> closeScreen())
+			.positionAndSize(width / 2 - 75, height - 33 / 2 - 10, 150, 20).build());
+	}
+
+	@Override
+	public void closeScreen() {
+		Profiles.getInstance().saveProfiles();
+		client.setScreen(parent);
+	}
+
+	public class ProfilesList extends ElementListWidget<ProfilesList.Entry> {
+		private static final Entry SPACER = new SpacerEntry();
+		private final Entry ADD = new NewEntry();
+
+		public ProfilesList(MinecraftClient minecraft, int width, int height, int top, int bottom, int itemHeight) {
+			super(minecraft, width, height, top, bottom, itemHeight);
+			reload();
+		}
+
+		public void reload() {
+			clearEntries();
+			Profiles.getInstance().iterateAvailable(p -> addEntry(new ProfileEntry(p)));
+			addEntry(SPACER);
+			addEntry(ADD);
+		}
+
+		@Override
+		public int getRowWidth() {
+			return 340;
+		}
+
+		@Override
+		public boolean mouseClicked(double mouseX, double mouseY, int button) {
+			children().stream().filter(e -> e instanceof ProfileEntry)
+				.map(e -> (ProfileEntry) e).map(e -> e.profileName).forEach(e -> e.setFocused(false));
+			return super.mouseClicked(mouseX, mouseY, button);
+		}
+
+		@Override
+		protected int getScrollbarPositionX() {
+			return getRowLeft() + getRowWidth() + 10;
+		}
+
+		@Environment(EnvType.CLIENT)
+		public abstract static class Entry extends ElementListWidget.Entry<Entry> {
+
+		}
+
+		public static class SpacerEntry extends Entry {
+
+			@Override
+			public List<? extends Selectable> selectableChildren() {
+				return List.of();
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of();
+			}
+		}
+
+		@Environment(EnvType.CLIENT)
+		public class ProfileEntry extends Entry {
+			private static final Text CURRENT_TEXT = Text.translatable("profiles.profile.current");
+			private static final Text LOAD_BUTTON_TITLE = Text.translatable("profiles.profile.load");
+			private static final Text DUPLICATE_BUTTON_TITLE = Text.translatable("profiles.profile.duplicate");
+			private static final Text REMOVE_BUTTON_TITLE = Text.translatable("profiles.profile.remove");
+			private final TextFieldWidget profileName;
+			private final ButtonWidget loadButton;
+			private final ButtonWidget duplicateButton;
+			private final ButtonWidget removeButton;
+			private final Profiles.Profile profile;
+
+			ProfileEntry(Profiles.Profile profile) {
+				this.profile = profile;
+				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, Text.empty());
+				profileName.setText(profile.name());
+				loadButton = ButtonWidget.builder(LOAD_BUTTON_TITLE, btn -> {
+					Profiles.getInstance().switchTo(profile);
+				}).positionAndSize(0, 0, 50, 20).build();
+				duplicateButton = ButtonWidget.builder(DUPLICATE_BUTTON_TITLE, b -> {
+					var dup = Profiles.getInstance().duplicate(profile);
+					double d = (double) ProfilesList.this.getMaxScroll() - ProfilesList.this.getScrollAmount();
+					ProfilesList.this.children().add(ProfilesList.this.children().indexOf(ProfileEntry.this) + 1, new ProfileEntry(dup));
+					ProfilesList.this.setScrollAmount(ProfilesList.this.getMaxScroll() - d);
+				}).positionAndSize(0, 0, 50, 20).build();
+
+				this.removeButton = ButtonWidget.builder(REMOVE_BUTTON_TITLE, b -> {
+						removeEntry(this);
+						Profiles.getInstance().remove(profile);
+						setScrollAmount(getScrollAmount());
+					}).positionAndSize(0, 0, 50, 20)
+					.build();
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - removeButton.getWidth() - 4;
+				int j = top - 2;
+				this.removeButton.setPosition(i, j);
+				this.removeButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				i -= duplicateButton.getWidth();
+				duplicateButton.setPosition(i, j);
+				duplicateButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				boolean current = Profiles.getInstance().getCurrent() == profile;
+				loadButton.setMessage(current ? CURRENT_TEXT : LOAD_BUTTON_TITLE);
+				loadButton.active = !current;
+				i -= loadButton.getWidth();
+				this.loadButton.setPosition(i, j);
+				this.loadButton.render(guiGraphics, mouseX, mouseY, partialTick);
+				profileName.setWidth(i - left - 4);
+				profileName.setPosition(left, j);
+				profileName.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+
+			@Override
+			public List<? extends Selectable> selectableChildren() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+		}
+
+		public class NewEntry extends Entry {
+
+			private final ButtonWidget addButton;
+
+			public NewEntry() {
+				this.addButton = ButtonWidget.builder(Text.translatable("profiles.profile.add"), button -> {
+						int i = ProfilesList.this.children().indexOf(this);
+						ProfilesList.this.children().add(Math.max(i - 1, 0), new ProfileEntry(Profiles.getInstance().newProfile(I18n.translate("profiles.profile.default_new_name"))));
+						Profiles.getInstance().saveProfiles();
+						setScrollAmount(getMaxScroll());
+					}).positionAndSize(0, 0, 150, 20)
+					.build();
+			}
+
+			@Override
+			public List<? extends Selectable> selectableChildren() {
+				return List.of(addButton);
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - width / 2 - 10 - addButton.getWidth() / 2;
+				int j = top - 2;
+				this.addButton.setPosition(i, j);
+				this.addButton.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(addButton);
+			}
+		}
+	}
+}

--- a/1.20/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.20/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.screen;
 
 import java.util.List;
@@ -121,9 +143,8 @@ public class ProfilesScreen extends Screen {
 				this.profile = profile;
 				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, Text.empty());
 				profileName.setText(profile.name());
-				loadButton = ButtonWidget.builder(LOAD_BUTTON_TITLE, btn -> {
-					Profiles.getInstance().switchTo(profile);
-				}).positionAndSize(0, 0, 50, 20).build();
+				loadButton = ButtonWidget.builder(LOAD_BUTTON_TITLE, btn ->
+					Profiles.getInstance().switchTo(profile)).positionAndSize(0, 0, 50, 20).build();
 				duplicateButton = ButtonWidget.builder(DUPLICATE_BUTTON_TITLE, b -> {
 					var dup = Profiles.getInstance().duplicate(profile);
 					double d = (double) ProfilesList.this.getMaxScroll() - ProfilesList.this.getScrollAmount();

--- a/1.20/src/main/java/io/github/axolotlclient/util/options/vanilla/AxoGraphicsWidget.java
+++ b/1.20/src/main/java/io/github/axolotlclient/util/options/vanilla/AxoGraphicsWidget.java
@@ -61,7 +61,7 @@ public class AxoGraphicsWidget extends GraphicsWidget {
 
 			int buttonX = gridX + maxGridWidth + 10;
 			int buttonY = gridY + 60;
-			var back = (ButtonWidget) children().getLast();
+			var back = (ButtonWidget) children().get(children().size()-1);
 			remove(back);
 			addDrawableChild(ButtonWidget.builder(Text.translatable("graphics.copy_text"),
 					btn -> client.keyboard.setClipboard(Base64.getEncoder().encodeToString(graphics.getPixelData())))

--- a/1.21.7/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
+++ b/1.21.7/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
@@ -35,6 +35,7 @@ import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.*;
 import io.github.axolotlclient.AxolotlClientConfigCommon;
 import io.github.axolotlclient.config.screen.CreditsScreen;
+import io.github.axolotlclient.config.screen.ProfilesScreen;
 import io.github.axolotlclient.mixin.OverlayTextureAccessor;
 import io.github.axolotlclient.util.keybinds.KeyBinds;
 import io.github.axolotlclient.util.options.ForceableBooleanOption;
@@ -168,6 +169,9 @@ public class AxolotlClientConfig extends AxolotlClientConfigCommon {
 		rendering.add(noRain);
 
 		hidden.add(creditsBGM, someNiceBackground);
+
+		general.add(new GenericOption("profiles.title", "profiles.configure", () ->
+			Minecraft.getInstance().setScreen(new ProfilesScreen(Minecraft.getInstance().screen))), false);
 
 		var toggleFullbright = new KeyMapping("toggle_fullbright", -1, "category.axolotlclient");
 		KeyBinds.getInstance().registerWithSimpleAction(toggleFullbright, fullBright::toggle);

--- a/1.21.7/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.21.7/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.screen;
 
 import java.util.List;

--- a/1.21.7/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.21.7/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,0 +1,221 @@
+package io.github.axolotlclient.config.screen;
+
+import java.util.List;
+
+import io.github.axolotlclient.config.profiles.Profiles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.ComponentPath;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.components.Button;
+import net.minecraft.client.gui.components.ContainerObjectSelectionList;
+import net.minecraft.client.gui.components.EditBox;
+import net.minecraft.client.gui.components.events.GuiEventListener;
+import net.minecraft.client.gui.layouts.HeaderAndFooterLayout;
+import net.minecraft.client.gui.layouts.LinearLayout;
+import net.minecraft.client.gui.narration.NarratableEntry;
+import net.minecraft.client.gui.navigation.FocusNavigationEvent;
+import net.minecraft.client.gui.screens.Screen;
+import net.minecraft.client.resources.language.I18n;
+import net.minecraft.network.chat.CommonComponents;
+import net.minecraft.network.chat.Component;
+import org.jetbrains.annotations.Nullable;
+
+public class ProfilesScreen extends Screen {
+
+	private final HeaderAndFooterLayout haL = new HeaderAndFooterLayout(this);
+	private ProfilesList profilesList;
+	private final Screen parent;
+	private boolean initialized;
+
+	public ProfilesScreen(Screen parent) {
+		super(Component.translatable("profiles.configure.list"));
+		this.parent = parent;
+	}
+
+	@Override
+	protected void init() {
+
+		if (!initialized) {
+			initialized = true;
+			haL.addTitleHeader(getTitle(), font);
+			profilesList = new ProfilesList(minecraft, 0, 0, 0, 25);
+			haL.addToContents(profilesList);
+			var footer = haL.addToFooter(LinearLayout.horizontal()).spacing(4);
+			footer.addChild(Button.builder(CommonComponents.GUI_BACK, btn -> onClose()).build());
+			haL.visitWidgets(this::addRenderableWidget);
+		}
+
+		repositionElements();
+	}
+
+	@Override
+	protected void repositionElements() {
+		haL.arrangeElements();
+		profilesList.updateSize(this.width, this.haL);
+	}
+
+	@Override
+	public void onClose() {
+		Profiles.getInstance().saveProfiles();
+		minecraft.setScreen(parent);
+	}
+
+	public class ProfilesList extends ContainerObjectSelectionList<ProfilesList.Entry> {
+		private static final Entry SPACER = new SpacerEntry();
+		private final Entry ADD = new NewEntry();
+
+		public ProfilesList(Minecraft minecraft, int width, int height, int y, int itemHeight) {
+			super(minecraft, width, height, y, itemHeight);
+			reload();
+		}
+
+		public void reload() {
+			clearEntries();
+			Profiles.getInstance().iterateAvailable(p -> addEntry(new ProfileEntry(p)));
+			addEntry(SPACER);
+			addEntry(ADD);
+		}
+
+		@Override
+		public int getRowWidth() {
+			return 340;
+		}
+
+		@Override
+		public boolean mouseClicked(double mouseX, double mouseY, int button) {
+			children().stream().filter(e -> e instanceof ProfileEntry)
+				.map(e -> (ProfileEntry) e).map(e -> e.profileName).forEach(e -> e.setFocused(false));
+			return super.mouseClicked(mouseX, mouseY, button);
+		}
+
+		@Environment(EnvType.CLIENT)
+		public abstract static class Entry extends ContainerObjectSelectionList.Entry<Entry> {
+
+		}
+
+		public static class SpacerEntry extends Entry {
+
+			@Override
+			public List<? extends NarratableEntry> narratables() {
+				return List.of();
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+
+			}
+
+			@Override
+			public List<? extends GuiEventListener> children() {
+				return List.of();
+			}
+
+			@Nullable
+			@Override
+			public ComponentPath nextFocusPath(FocusNavigationEvent event) {
+				return null;
+			}
+		}
+
+		@Environment(EnvType.CLIENT)
+		public class ProfileEntry extends Entry {
+			private static final Component CURRENT_TEXT = Component.translatable("profiles.profile.current");
+			private static final Component LOAD_BUTTON_TITLE = Component.translatable("profiles.profile.load");
+			private static final Component DUPLICATE_BUTTON_TITLE = Component.translatable("profiles.profile.duplicate");
+			private static final Component REMOVE_BUTTON_TITLE = Component.translatable("profiles.profile.remove");
+			private final EditBox profileName;
+			private final Button loadButton;
+			private final Button duplicateButton;
+			private final Button removeButton;
+			private final Profiles.Profile profile;
+
+			ProfileEntry(Profiles.Profile profile) {
+				this.profile = profile;
+				profileName = new EditBox(getFont(), 0, 0, 150, 20, Component.empty());
+				profileName.setValue(profile.name());
+				loadButton = Button.builder(LOAD_BUTTON_TITLE, btn ->
+					Profiles.getInstance().switchTo(profile)).bounds(0, 0, 50, 20).build();
+				duplicateButton = Button.builder(DUPLICATE_BUTTON_TITLE, b -> {
+					var dup = Profiles.getInstance().duplicate(profile);
+					double d = (double) ProfilesList.this.maxScrollAmount() - ProfilesList.this.scrollAmount();
+					ProfilesList.this.children().add(ProfilesList.this.children().indexOf(ProfileEntry.this) + 1, new ProfileEntry(dup));
+					ProfilesList.this.setScrollAmount(ProfilesList.this.maxScrollAmount() - d);
+				}).bounds(0, 0, 50, 20).build();
+
+				this.removeButton = Button.builder(REMOVE_BUTTON_TITLE, b -> {
+						removeEntry(this);
+						Profiles.getInstance().remove(profile);
+						refreshScrollAmount();
+					}).bounds(0, 0, 50, 20)
+					.build();
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = scrollBarX() - removeButton.getWidth() - 4;
+				int j = top - 2;
+				this.removeButton.setPosition(i, j);
+				this.removeButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				i -= duplicateButton.getWidth();
+				duplicateButton.setPosition(i, j);
+				duplicateButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				boolean current = Profiles.getInstance().getCurrent() == profile;
+				loadButton.setMessage(current ? CURRENT_TEXT : LOAD_BUTTON_TITLE);
+				loadButton.active = !current;
+				i -= loadButton.getWidth();
+				this.loadButton.setPosition(i, j);
+				this.loadButton.render(guiGraphics, mouseX, mouseY, partialTick);
+				profileName.setWidth(i - left - 4);
+				profileName.setPosition(left, j);
+				profileName.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends GuiEventListener> children() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+
+			@Override
+			public List<? extends NarratableEntry> narratables() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+		}
+
+		public class NewEntry extends Entry {
+
+			private final Button addButton;
+
+			public NewEntry() {
+				this.addButton = Button.builder(Component.translatable("profiles.profile.add"), button -> {
+						int i = ProfilesList.this.children().indexOf(this);
+						ProfilesList.this.children().add(Math.max(i - 1, 0), new ProfilesList.ProfileEntry(Profiles.getInstance().newProfile(I18n.get("profiles.profile.default_new_name"))));
+						Profiles.getInstance().saveProfiles();
+						setScrollAmount(maxScrollAmount());
+					}).bounds(0, 0, 150, 20)
+					.build();
+			}
+
+			@Override
+			public List<? extends NarratableEntry> narratables() {
+				return List.of(addButton);
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = scrollBarX() - width / 2 - 10 - addButton.getWidth() / 2;
+				int j = top - 2;
+				this.addButton.setPosition(i, j);
+				this.addButton.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends GuiEventListener> children() {
+				return List.of(addButton);
+			}
+		}
+	}
+}

--- a/1.21.7/src/main/java/io/github/axolotlclient/mixin/SplashOverlayMixin.java
+++ b/1.21.7/src/main/java/io/github/axolotlclient/mixin/SplashOverlayMixin.java
@@ -25,7 +25,6 @@ package io.github.axolotlclient.mixin;
 import java.util.function.IntSupplier;
 
 import io.github.axolotlclient.AxolotlClient;
-import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.api.API;
 import io.github.axolotlclient.modules.auth.Auth;
 import net.fabricmc.loader.api.FabricLoader;
@@ -51,8 +50,7 @@ public abstract class SplashOverlayMixin {
 	private static void axolotlclient$customBackgroundColor(CallbackInfo ci) {
 		if (!FabricLoader.getInstance().isModLoaded("dark-loading-screen")) {
 			if (AxolotlClient.config() != null) {
-				Color color = AxolotlClient.config().loadingScreenColor.get();
-				BRAND_BACKGROUND = color::toInt;
+				BRAND_BACKGROUND = AxolotlClient.config().loadingScreenColor.get()::toInt;
 				//ColorUtil.Argb32.of(color.getAlpha(), color.getRed(), color.getGreen(), color.getBlue());
 			}
 		}

--- a/1.21/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
+++ b/1.21/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
@@ -36,6 +36,7 @@ import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.*;
 import io.github.axolotlclient.AxolotlClientConfigCommon;
 import io.github.axolotlclient.config.screen.CreditsScreen;
+import io.github.axolotlclient.config.screen.ProfilesScreen;
 import io.github.axolotlclient.mixin.OverlayTextureAccessor;
 import io.github.axolotlclient.util.keybinds.KeyBinds;
 import io.github.axolotlclient.util.options.ForceableBooleanOption;
@@ -182,6 +183,9 @@ public class AxolotlClientConfig extends AxolotlClientConfigCommon {
 		rendering.add(noRain);
 
 		hidden.add(creditsBGM, someNiceBackground);
+
+		general.add(new GenericOption("profiles.title", "profiles.configure", () ->
+			MinecraftClient.getInstance().setScreen(new ProfilesScreen(MinecraftClient.getInstance().currentScreen))), false);
 
 		var toggleFullbright = new KeyBind("toggle_fullbright", -1, "category.axolotlclient");
 		KeyBinds.getInstance().registerWithSimpleAction(toggleFullbright, fullBright::toggle);

--- a/1.21/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.21/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.screen;
 
 import java.util.List;

--- a/1.21/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.21/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,0 +1,212 @@
+package io.github.axolotlclient.config.screen;
+
+import java.util.List;
+
+import io.github.axolotlclient.config.profiles.Profiles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.Element;
+import net.minecraft.client.gui.GuiGraphics;
+import net.minecraft.client.gui.Selectable;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.gui.widget.TextFieldWidget;
+import net.minecraft.client.gui.widget.button.ButtonWidget;
+import net.minecraft.client.gui.widget.layout.HeaderFooterLayoutWidget;
+import net.minecraft.client.gui.widget.layout.LinearLayoutWidget;
+import net.minecraft.client.gui.widget.list.ElementListWidget;
+import net.minecraft.client.resource.language.I18n;
+import net.minecraft.text.CommonTexts;
+import net.minecraft.text.Text;
+
+public class ProfilesScreen extends Screen {
+
+	private final HeaderFooterLayoutWidget haL = new HeaderFooterLayoutWidget(this);
+	private ProfilesList profilesList;
+	private final Screen parent;
+	private boolean initialized;
+
+	public ProfilesScreen(Screen parent) {
+		super(Text.translatable("profiles.configure.list"));
+		this.parent = parent;
+	}
+
+	@Override
+	protected void init() {
+
+		if (!initialized) {
+			initialized = true;
+			haL.addToHeader(getTitle(), textRenderer);
+			profilesList = new ProfilesList(client, 0, 0, 0, 25);
+			haL.addToContents(profilesList);
+			var footer = haL.addToFooter(LinearLayoutWidget.createHorizontal()).setSpacing(4);
+			footer.add(ButtonWidget.builder(CommonTexts.BACK, btn -> closeScreen()).build());
+			haL.visitWidgets(this::addDrawableSelectableElement);
+		}
+
+		repositionElements();
+	}
+
+	@Override
+	protected void repositionElements() {
+		haL.arrangeElements();
+		profilesList.setDimensionsWithLayout(this.width, this.haL);
+	}
+
+	@Override
+	public void closeScreen() {
+		Profiles.getInstance().saveProfiles();
+		client.setScreen(parent);
+	}
+
+	public class ProfilesList extends ElementListWidget<ProfilesList.Entry> {
+		private static final Entry SPACER = new SpacerEntry();
+		private final Entry ADD = new NewEntry();
+
+		public ProfilesList(MinecraftClient minecraft, int width, int height, int y, int itemHeight) {
+			super(minecraft, width, height, y, itemHeight);
+			reload();
+		}
+
+		public void reload() {
+			clearEntries();
+			Profiles.getInstance().iterateAvailable(p -> addEntry(new ProfileEntry(p)));
+			addEntry(SPACER);
+			addEntry(ADD);
+		}
+
+		@Override
+		public int getRowWidth() {
+			return 340;
+		}
+
+		@Override
+		public boolean mouseClicked(double mouseX, double mouseY, int button) {
+			children().stream().filter(e -> e instanceof ProfileEntry)
+				.map(e -> (ProfileEntry) e).map(e -> e.profileName).forEach(e -> e.setFocused(false));
+			return super.mouseClicked(mouseX, mouseY, button);
+		}
+
+		@Environment(EnvType.CLIENT)
+		public abstract static class Entry extends ElementListWidget.Entry<Entry> {
+
+		}
+
+		public static class SpacerEntry extends Entry {
+
+			@Override
+			public List<? extends Selectable> selectableChildren() {
+				return List.of();
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of();
+			}
+		}
+
+		@Environment(EnvType.CLIENT)
+		public class ProfileEntry extends Entry {
+			private static final Text CURRENT_TEXT = Text.translatable("profiles.profile.current");
+			private static final Text LOAD_BUTTON_TITLE = Text.translatable("profiles.profile.load");
+			private static final Text DUPLICATE_BUTTON_TITLE = Text.translatable("profiles.profile.duplicate");
+			private static final Text REMOVE_BUTTON_TITLE = Text.translatable("profiles.profile.remove");
+			private final TextFieldWidget profileName;
+			private final ButtonWidget loadButton;
+			private final ButtonWidget duplicateButton;
+			private final ButtonWidget removeButton;
+			private final Profiles.Profile profile;
+
+			ProfileEntry(Profiles.Profile profile) {
+				this.profile = profile;
+				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, Text.empty());
+				profileName.setText(profile.name());
+				loadButton = ButtonWidget.builder(LOAD_BUTTON_TITLE, btn ->
+					Profiles.getInstance().switchTo(profile)).positionAndSize(0, 0, 50, 20).build();
+				duplicateButton = ButtonWidget.builder(DUPLICATE_BUTTON_TITLE, b -> {
+					var dup = Profiles.getInstance().duplicate(profile);
+					double d = (double) ProfilesList.this.getMaxScroll() - ProfilesList.this.getScrollAmount();
+					ProfilesList.this.children().add(ProfilesList.this.children().indexOf(ProfileEntry.this) + 1, new ProfileEntry(dup));
+					ProfilesList.this.setScrollAmount(ProfilesList.this.getMaxScroll() - d);
+				}).positionAndSize(0, 0, 50, 20).build();
+
+				this.removeButton = ButtonWidget.builder(REMOVE_BUTTON_TITLE, b -> {
+						removeEntry(this);
+						Profiles.getInstance().remove(profile);
+						refreshScrollAmount();
+					}).positionAndSize(0, 0, 50, 20)
+					.build();
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - removeButton.getWidth() - 4;
+				int j = top - 2;
+				this.removeButton.setPosition(i, j);
+				this.removeButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				i -= duplicateButton.getWidth();
+				duplicateButton.setPosition(i, j);
+				duplicateButton.render(guiGraphics, mouseX, mouseY, partialTick);
+
+				boolean current = Profiles.getInstance().getCurrent() == profile;
+				loadButton.setMessage(current ? CURRENT_TEXT : LOAD_BUTTON_TITLE);
+				loadButton.active = !current;
+				i -= loadButton.getWidth();
+				this.loadButton.setPosition(i, j);
+				this.loadButton.render(guiGraphics, mouseX, mouseY, partialTick);
+				profileName.setWidth(i - left - 4);
+				profileName.setPosition(left, j);
+				profileName.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+
+			@Override
+			public List<? extends Selectable> selectableChildren() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+		}
+
+		public class NewEntry extends Entry {
+
+			private final ButtonWidget addButton;
+
+			public NewEntry() {
+				this.addButton = ButtonWidget.builder(Text.translatable("profiles.profile.add"), button -> {
+						int i = ProfilesList.this.children().indexOf(this);
+						ProfilesList.this.children().add(Math.max(i - 1, 0), new ProfileEntry(Profiles.getInstance().newProfile(I18n.translate("profiles.profile.default_new_name"))));
+						Profiles.getInstance().saveProfiles();
+						setScrollAmount(getMaxScroll());
+					}).positionAndSize(0, 0, 150, 20)
+					.build();
+			}
+
+			@Override
+			public List<? extends Selectable> selectableChildren() {
+				return List.of(addButton);
+			}
+
+			@Override
+			public void render(GuiGraphics guiGraphics, int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - width / 2 - 10 - addButton.getWidth() / 2;
+				int j = top - 2;
+				this.addButton.setPosition(i, j);
+				this.addButton.render(guiGraphics, mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(addButton);
+			}
+		}
+	}
+}

--- a/1.8.9/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/config/AxolotlClientConfig.java
@@ -34,6 +34,7 @@ import io.github.axolotlclient.AxolotlClientConfig.api.util.Color;
 import io.github.axolotlclient.AxolotlClientConfig.impl.options.*;
 import io.github.axolotlclient.AxolotlClientConfigCommon;
 import io.github.axolotlclient.config.screen.CreditsScreen;
+import io.github.axolotlclient.config.screen.ProfilesScreen;
 import io.github.axolotlclient.modules.Module;
 import io.github.axolotlclient.util.GLFWUtil;
 import io.github.axolotlclient.util.options.ForceableBooleanOption;
@@ -180,6 +181,9 @@ public class AxolotlClientConfig extends AxolotlClientConfigCommon {
 				GLFWUtil.runUsingGlfwHandle(h -> GLFW.glfwSetInputMode(h, GLFW.GLFW_RAW_MOUSE_MOTION, rawMouseInput.get() ? 1 : 0));
 			}
 		});
+
+		general.add(new GenericOption("profiles.title", "profiles.configure", () ->
+			Minecraft.getInstance().openScreen(new ProfilesScreen(Minecraft.getInstance().screen))), false);
 
 		var toggleFullbright = new KeyBinding("toggle_fullbright", 0, "category.axolotlclient");
 		KeyBindingEvents.REGISTER_KEYBINDS.register(reg -> reg.register(toggleFullbright));

--- a/1.8.9/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,0 +1,183 @@
+package io.github.axolotlclient.config.screen;
+
+import java.util.List;
+
+import io.github.axolotlclient.AxolotlClientConfig.impl.ui.ButtonWidget;
+import io.github.axolotlclient.AxolotlClientConfig.impl.ui.Element;
+import io.github.axolotlclient.AxolotlClientConfig.impl.ui.TextFieldWidget;
+import io.github.axolotlclient.AxolotlClientConfig.impl.ui.vanilla.ElementListWidget;
+import io.github.axolotlclient.AxolotlClientConfig.impl.ui.vanilla.widgets.VanillaButtonWidget;
+import io.github.axolotlclient.config.profiles.Profiles;
+import net.fabricmc.api.EnvType;
+import net.fabricmc.api.Environment;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.resource.language.I18n;
+
+public class ProfilesScreen extends io.github.axolotlclient.AxolotlClientConfig.impl.ui.Screen {
+
+	private final Screen parent;
+
+	public ProfilesScreen(Screen parent) {
+		super(I18n.translate("profiles.configure.list"));
+		this.parent = parent;
+	}
+
+	@Override
+	public void render(int mouseX, int mouseY, float delta) {
+		super.render(mouseX, mouseY, delta);
+		drawCenteredString(textRenderer, getTitle(), width / 2, 33 / 2 - textRenderer.fontHeight / 2, -1);
+	}
+
+	@Override
+	public void init() {
+		addDrawableChild(new ProfilesList(minecraft, width, height, 33, height - 33, 25));
+
+		addDrawableChild(new VanillaButtonWidget(width / 2 - 75, height - 33 / 2 - 10, 150, 20, I18n.translate("gui.back"), btn -> closeScreen()));
+	}
+
+
+	public void closeScreen() {
+		Profiles.getInstance().saveProfiles();
+		minecraft.openScreen(parent);
+	}
+
+	public class ProfilesList extends ElementListWidget<ProfilesList.Entry> {
+		private static final Entry SPACER = new SpacerEntry();
+		private final Entry ADD = new NewEntry();
+
+		public ProfilesList(Minecraft minecraft, int width, int height, int top, int bottom, int itemHeight) {
+			super(minecraft, width, height, top, bottom, itemHeight);
+			reload();
+		}
+
+		public void reload() {
+			clearEntries();
+			Profiles.getInstance().iterateAvailable(p -> addEntry(new ProfileEntry(p)));
+			addEntry(SPACER);
+			addEntry(ADD);
+		}
+
+		@Override
+		protected int getScrollbarPositionX() {
+			return getRowLeft() + getRowWidth() + 10;
+		}
+
+		@Override
+		public int getRowWidth() {
+			return 340;
+		}
+
+		@Override
+		public boolean mouseClicked(double mouseX, double mouseY, int button) {
+			children().stream().filter(e -> e instanceof ProfileEntry)
+				.map(e -> (ProfileEntry) e).map(e -> e.profileName).forEach(e -> e.setFocused(false));
+			return super.mouseClicked(mouseX, mouseY, button);
+		}
+
+		@Environment(EnvType.CLIENT)
+		public abstract static class Entry extends ElementListWidget.Entry<Entry> {
+
+		}
+
+		public static class SpacerEntry extends Entry {
+			@Override
+			public void render(int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of();
+			}
+		}
+
+		@Environment(EnvType.CLIENT)
+		public class ProfileEntry extends Entry {
+			private static final String CURRENT_TEXT = I18n.translate("profiles.profile.current");
+			private static final String LOAD_BUTTON_TITLE = I18n.translate("profiles.profile.load");
+			private static final String DUPLICATE_BUTTON_TITLE = I18n.translate("profiles.profile.duplicate");
+			private static final String REMOVE_BUTTON_TITLE = I18n.translate("profiles.profile.remove");
+			private final TextFieldWidget profileName;
+			private final ButtonWidget loadButton;
+			private final ButtonWidget duplicateButton;
+			private final ButtonWidget removeButton;
+			private final Profiles.Profile profile;
+
+			ProfileEntry(Profiles.Profile profile) {
+				this.profile = profile;
+				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, "");
+				profileName.setText(profile.name());
+				loadButton = new VanillaButtonWidget(0, 0, 50, 20, LOAD_BUTTON_TITLE, btn -> {
+					Profiles.getInstance().switchTo(profile);
+				});
+				duplicateButton = new VanillaButtonWidget(0, 0, 50, 20, DUPLICATE_BUTTON_TITLE, b -> {
+					var dup = Profiles.getInstance().duplicate(profile);
+					double d = (double) ProfilesList.this.getMaxScroll() - ProfilesList.this.getScrollAmount();
+					ProfilesList.this.children().add(ProfilesList.this.children().indexOf(ProfileEntry.this) + 1, new ProfileEntry(dup));
+					ProfilesList.this.setScrollAmount(ProfilesList.this.getMaxScroll() - d);
+				});
+
+				this.removeButton = new VanillaButtonWidget(0, 0, 50, 20, REMOVE_BUTTON_TITLE, b -> {
+					removeEntry(this);
+					Profiles.getInstance().remove(profile);
+					setScrollAmount(getScrollAmount());
+				});
+			}
+
+			@Override
+			public void render(int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - removeButton.getWidth() - 4;
+				int j = top - 2;
+				this.removeButton.setPosition(i, j);
+				this.removeButton.render(mouseX, mouseY, partialTick);
+
+				i -= duplicateButton.getWidth();
+				duplicateButton.setPosition(i, j);
+				duplicateButton.render(mouseX, mouseY, partialTick);
+
+				boolean current = Profiles.getInstance().getCurrent() == profile;
+				loadButton.setMessage(current ? CURRENT_TEXT : LOAD_BUTTON_TITLE);
+				loadButton.active = !current;
+				i -= loadButton.getWidth();
+				this.loadButton.setPosition(i, j);
+				this.loadButton.render(mouseX, mouseY, partialTick);
+				profileName.setWidth(i - left - 4);
+				profileName.setPosition(left, j);
+				profileName.render(mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(profileName, this.loadButton, duplicateButton, removeButton);
+			}
+		}
+
+		public class NewEntry extends Entry {
+
+			private final ButtonWidget addButton;
+
+			public NewEntry() {
+				this.addButton = new VanillaButtonWidget(0, 0, 150, 20, I18n.translate("profiles.profile.add"), button -> {
+					int i = ProfilesList.this.children().indexOf(this);
+					ProfilesList.this.children().add(Math.max(i - 1, 0), new ProfileEntry(Profiles.getInstance().newProfile(I18n.translate("profiles.profile.default_new_name"))));
+					Profiles.getInstance().saveProfiles();
+					setScrollAmount(getMaxScroll());
+				});
+			}
+
+			@Override
+			public void render(int index, int top, int left, int width, int height, int mouseX, int mouseY, boolean hovering, float partialTick) {
+				int i = getScrollbarPositionX() - width / 2 - 10 - addButton.getWidth() / 2;
+				int j = top - 2;
+				this.addButton.setPosition(i, j);
+				this.addButton.render(mouseX, mouseY, partialTick);
+			}
+
+			@Override
+			public List<? extends Element> children() {
+				return List.of(addButton);
+			}
+		}
+	}
+}

--- a/1.8.9/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
+++ b/1.8.9/src/main/java/io/github/axolotlclient/config/screen/ProfilesScreen.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.screen;
 
 import java.util.List;
@@ -108,9 +130,8 @@ public class ProfilesScreen extends io.github.axolotlclient.AxolotlClientConfig.
 				this.profile = profile;
 				profileName = new TextFieldWidget(textRenderer, 0, 0, 150, 20, "");
 				profileName.setText(profile.name());
-				loadButton = new VanillaButtonWidget(0, 0, 50, 20, LOAD_BUTTON_TITLE, btn -> {
-					Profiles.getInstance().switchTo(profile);
-				});
+				loadButton = new VanillaButtonWidget(0, 0, 50, 20, LOAD_BUTTON_TITLE, btn ->
+					Profiles.getInstance().switchTo(profile));
 				duplicateButton = new VanillaButtonWidget(0, 0, 50, 20, DUPLICATE_BUTTON_TITLE, b -> {
 					var dup = Profiles.getInstance().duplicate(profile);
 					double d = (double) ProfilesList.this.getMaxScroll() - ProfilesList.this.getScrollAmount();

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -68,7 +68,7 @@ subprojects {
 
 	tasks.getByName("jar", Jar::class) {
 		filesMatching("LICENSE") {
-			rename("^(LICENSE.*?)(\\..*)?$", "\$1_${archiveBaseName}\$2")
+			rename("^(LICENSE.*?)(\\..*)?$", "$1_${archiveBaseName}$2")
 		}
 	}
 

--- a/common/src/main/java/io/github/axolotlclient/AxolotlClientCommon.java
+++ b/common/src/main/java/io/github/axolotlclient/AxolotlClientCommon.java
@@ -35,10 +35,13 @@ import com.google.gson.JsonObject;
 import io.github.axolotlclient.AxolotlClientConfig.api.AxolotlClientConfig;
 import io.github.axolotlclient.AxolotlClientConfig.api.manager.ConfigManager;
 import io.github.axolotlclient.AxolotlClientConfig.api.ui.ConfigUI;
+import io.github.axolotlclient.AxolotlClientConfig.impl.managers.JsonConfigManager;
 import io.github.axolotlclient.AxolotlClientConfig.impl.managers.VersionedJsonConfigManager;
 import io.github.axolotlclient.api.API;
 import io.github.axolotlclient.bridge.events.Events;
 import io.github.axolotlclient.bridge.util.AxoIdentifier;
+import io.github.axolotlclient.config.profiles.ProfileAware;
+import io.github.axolotlclient.config.profiles.Profiles;
 import io.github.axolotlclient.modules.Module;
 import io.github.axolotlclient.modules.hud.ClickInputTracker;
 import io.github.axolotlclient.util.Logger;
@@ -53,6 +56,10 @@ public abstract class AxolotlClientCommon {
 	// static utility methods
 	public static Path resolveConfigFile(String file) {
 		return FabricLoader.getInstance().getConfigDir().resolve(MODID).resolve(file);
+	}
+
+	public static Path resolveProfileConfigFile(String file) {
+		return Profiles.getInstance().resolveProfileFile(file);
 	}
 
 	public static final boolean NVG_SUPPORTED = OSUtil.getOS() != OSUtil.OperatingSystem.OTHER &&
@@ -77,7 +84,7 @@ public abstract class AxolotlClientCommon {
 	private AxolotlClientConfigCommon config;
 	private Logger logger;
 	private NotificationProvider notificationProvider;
-	private ConfigManager configManager;
+	private JsonConfigManager configManager;
 	private boolean initializing = false;
 	public final List<Module> modules = new ArrayList<>();
 
@@ -126,8 +133,20 @@ public abstract class AxolotlClientCommon {
 	}
 
 	private void initConfig() {
-		AxolotlClientConfig.getInstance()
-			.register(configManager = new VersionedJsonConfigManager(getMainConfigFile(),
+		var configFile = getMainConfigFile();
+		if (Files.notExists(configFile)) {
+			var legacy = new Path[]{resolveConfigFile("axolotlclient.json"), FabricLoader.getInstance().getConfigDir().resolve("AxolotlClient.json")};
+			for (Path p : legacy) {
+				try {
+					if (Files.exists(p)) {
+						Files.move(p, configFile);
+					}
+				} catch (IOException e) {
+					logger.warn("Failed to move config file, it might get reset! ", e);
+				}
+			}
+		}
+		configManager = new VersionedJsonConfigManager(configFile,
 				config.getConfig(), 5, (oldVersion, newVersion, config, json) -> {
 				if (oldVersion.getMajor() <= 1) {
 					if (json.has("hud")) {
@@ -188,7 +207,7 @@ public abstract class AxolotlClientCommon {
 					}
 				}
 				return json;
-			}));
+			});
 
 		AxolotlClientConfig.getInstance().register(configManager);
 
@@ -205,6 +224,8 @@ public abstract class AxolotlClientCommon {
 
 		initializing = true;
 		instance = this;
+
+		Profiles.getInstance().loadProfiles();
 
 		this.logger = logger;
 		this.notificationProvider = provider;
@@ -243,16 +264,23 @@ public abstract class AxolotlClientCommon {
 	}
 
 	public Path getMainConfigFile() {
-		var legacy = FabricLoader.getInstance().getConfigDir().resolve("AxolotlClient.json");
-		var current = resolveConfigFile("axolotlclient.json");
+		var path = resolveProfileConfigFile("axolotlclient.json");
 		try {
-			if (Files.exists(legacy)) {
-				Files.createDirectories(current.getParent());
-				Files.move(legacy, current);
-			}
+			Files.createDirectories(path.getParent());
 		} catch (IOException e) {
-			logger.warn("Failed to move config file, it might get reset! ", e);
+			getLogger().warn("Failed to create config directory, config may not be saved correctly!", e);
 		}
-		return current;
+		return path;
+	}
+
+	public void reloadConfig() {
+		configManager.setFile(getMainConfigFile());
+		configManager.load();
+		for (Module m : modules) {
+			if (m instanceof ProfileAware p) {
+				p.reloadConfig();
+			}
+		}
+		lateModuleInit();
 	}
 }

--- a/common/src/main/java/io/github/axolotlclient/config/profiles/ProfileAware.java
+++ b/common/src/main/java/io/github/axolotlclient/config/profiles/ProfileAware.java
@@ -1,0 +1,6 @@
+package io.github.axolotlclient.config.profiles;
+
+public interface ProfileAware {
+
+	void reloadConfig();
+}

--- a/common/src/main/java/io/github/axolotlclient/config/profiles/ProfileAware.java
+++ b/common/src/main/java/io/github/axolotlclient/config/profiles/ProfileAware.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.profiles;
 
 public interface ProfileAware {

--- a/common/src/main/java/io/github/axolotlclient/config/profiles/Profiles.java
+++ b/common/src/main/java/io/github/axolotlclient/config/profiles/Profiles.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright © 2025 moehreag <moehreag@gmail.com> & Contributors
+ *
+ * This file is part of AxolotlClient.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ *
+ * For more information, see the LICENSE file.
+ */
+
 package io.github.axolotlclient.config.profiles;
 
 import java.io.IOException;

--- a/common/src/main/java/io/github/axolotlclient/config/profiles/Profiles.java
+++ b/common/src/main/java/io/github/axolotlclient/config/profiles/Profiles.java
@@ -1,0 +1,174 @@
+package io.github.axolotlclient.config.profiles;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.*;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import com.google.common.hash.Hashing;
+import com.google.gson.TypeAdapter;
+import com.google.gson.annotations.JsonAdapter;
+import com.google.gson.stream.JsonReader;
+import com.google.gson.stream.JsonToken;
+import com.google.gson.stream.JsonWriter;
+import io.github.axolotlclient.AxolotlClientCommon;
+import io.github.axolotlclient.bridge.util.AxoI18n;
+import io.github.axolotlclient.util.GsonHelper;
+
+public class Profiles {
+	private static final Path PROFILES_CONFIG = AxolotlClientCommon.resolveConfigFile("profiles").resolve("profiles.json");
+
+	public static Profiles getInstance() {
+		return INSTANCE;
+	}
+
+	private static final Profiles INSTANCE = new Profiles();
+
+	private ProfileStorage storage;
+
+	public void loadProfiles() {
+		if (Files.exists(PROFILES_CONFIG)) {
+			try (var stream = Files.newBufferedReader(PROFILES_CONFIG)) {
+				storage = GsonHelper.GSON.fromJson(stream, ProfileStorage.class);
+			} catch (IOException e) {
+				AxolotlClientCommon.getInstance().getLogger().warn("Failed to load profiles!", e);
+			}
+		} else {
+			storage = new ProfileStorage();
+			storage.current = newProfile("Default");
+			saveProfiles();
+			for (String name : new String[]{"axolotlclient.json", "custom_hud.json", "keystrokes.json"}) {
+				var oldPath = AxolotlClientCommon.resolveConfigFile(name);
+				var newPath = resolveProfileFile(name);
+				try {
+					Files.createDirectories(newPath.getParent());
+					Files.move(oldPath, newPath);
+				} catch (IOException e) {
+					AxolotlClientCommon.getInstance().getLogger().warn("Failed to move {} to profile-based config path at {}", oldPath, newPath, e);
+				}
+			}
+		}
+	}
+
+	public void saveProfiles() {
+		try {
+			Files.createDirectories(PROFILES_CONFIG.getParent());
+			try (var stream = Files.newBufferedWriter(PROFILES_CONFIG)) {
+				GsonHelper.GSON.toJson(storage, stream);
+			}
+		} catch (IOException e) {
+			AxolotlClientCommon.getInstance().getLogger().warn("Failed to save profiles, falling back to 'default'", e);
+		}
+	}
+
+	public void iterateAvailable(Consumer<Profile> action) {
+		storage.available().forEach(action);
+	}
+
+	public void remove(Profile profile) {
+		storage.available().remove(profile);
+	}
+
+	public void switchTo(Profile profile) {
+		if (!storage.available().contains(profile)) {
+			throw new IllegalArgumentException("Unknown profile!");
+		}
+		storage.current = profile;
+		AxolotlClientCommon.getInstance().reloadConfig();
+	}
+
+	public Profile getCurrent() {
+		return storage.current();
+	}
+
+	public Path resolveProfileFile(String path) {
+		return getCurrent().getPath().resolve(path);
+	}
+
+	@SuppressWarnings("UnstableApiUsage")
+	public Profile newProfile(String name) {
+		var p = new Profile(name, Hashing.sha512().hashUnencodedChars(UUID.randomUUID().toString()).toString());
+		storage.available().add(p);
+		return p;
+	}
+
+	public Profile duplicate(Profile profile) {
+		var duplicate = newProfile(AxoI18n.translate("profiles.duplicated", profile.name()));
+		try {
+			Files.copy(profile.getPath(), duplicate.getPath());
+		} catch (IOException e) {
+			AxolotlClientCommon.getInstance().getLogger().warn("Failed to duplicate profile!");
+		}
+		return duplicate;
+	}
+
+	public record Profile(String name, String id) {
+		public Path getPath() {
+			return AxolotlClientCommon.resolveConfigFile("profiles").resolve(id());
+		}
+	}
+
+	@JsonAdapter(ProfileStorageLoader.class)
+	public static final class ProfileStorage {
+		private Profile current;
+		private final List<Profile> available = new ArrayList<>();
+
+		private ProfileStorage(Profile current, Collection<Profile> available) {
+			this.current = current;
+			this.available.addAll(available);
+		}
+
+		private ProfileStorage() {
+
+		}
+
+		public Profile current() {
+			return current;
+		}
+
+		public List<Profile> available() {
+			return available;
+		}
+	}
+
+	public static class ProfileStorageLoader extends TypeAdapter<ProfileStorage> {
+
+		@Override
+		public void write(JsonWriter out, ProfileStorage value) throws IOException {
+			if (value == null) {
+				out.nullValue();
+				return;
+			}
+
+			out.beginObject();
+			out.name("current").value(value.current().id());
+			out.name("available").beginArray();
+			for (Profile entry : value.available()) {
+				out.beginObject();
+				out.name("name").value(entry.name());
+				out.name("id").value(entry.id());
+				out.endObject();
+			}
+			out.endArray();
+			out.endObject();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public ProfileStorage read(JsonReader in) throws IOException {
+			if (in.peek() != JsonToken.BEGIN_OBJECT) {
+				return null;
+			}
+
+			Map<String, Object> obj = (Map<String, Object>) GsonHelper.read(in);
+			if (obj == null) return null;
+			var available = ((List<Map<String, String>>) obj.get("available")).stream()
+				.map(e -> new Profile(e.get("name"), e.get("id"))).toList();
+			Map<String, Profile> profiles = available.stream().collect(Collectors.toMap(Profile::id, Function.identity()));
+			return new ProfileStorage(profiles.get((String) obj.get("current")), available);
+		}
+	}
+}

--- a/common/src/main/java/io/github/axolotlclient/modules/hud/HudManagerCommon.java
+++ b/common/src/main/java/io/github/axolotlclient/modules/hud/HudManagerCommon.java
@@ -24,7 +24,6 @@ package io.github.axolotlclient.modules.hud;
 
 import java.io.IOException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -41,6 +40,7 @@ import io.github.axolotlclient.bridge.key.AxoKeys;
 import io.github.axolotlclient.bridge.render.AxoRenderContext;
 import io.github.axolotlclient.bridge.render.AxoWindow;
 import io.github.axolotlclient.bridge.util.AxoIdentifier;
+import io.github.axolotlclient.config.profiles.ProfileAware;
 import io.github.axolotlclient.modules.AbstractCommonModule;
 import io.github.axolotlclient.modules.hud.gui.component.HudEntry;
 import io.github.axolotlclient.modules.hud.gui.component.Positionable;
@@ -63,11 +63,11 @@ import lombok.Getter;
  *
  * @license GPL-3.0
  */
-public abstract class HudManagerCommon extends AbstractCommonModule {
+public abstract class HudManagerCommon extends AbstractCommonModule implements ProfileAware {
 	@Getter
 	private static HudManagerCommon instance;
 
-	private final static Path CUSTOM_MODULE_SAVE_PATH = AxolotlClientCommon.resolveConfigFile("custom_hud.json");
+	private final static String CUSTOM_MODULE_SAVE_FILE_NAME = "custom_hud.json";
 	private final AxoKeybinding key = AxoKeybinding.create(AxoKeys.KEY_RSHIFT, "key.openHud", "category.axolotlclient");
 	private final AxoKeybinding toggleHud = AxoKeybinding.create(AxoKeys.KEY_UNKNOWN, "key.toggle_hud", "category.axolotlclient");
 	private final OptionCategory hudCategory = OptionCategory.create("hud");
@@ -141,10 +141,11 @@ public abstract class HudManagerCommon extends AbstractCommonModule {
 	}
 
 	@SuppressWarnings("unchecked")
-	private void loadCustomEntries() {
+	public void loadCustomEntries() {
 		try {
-			if (Files.exists(CUSTOM_MODULE_SAVE_PATH)) {
-				var obj = (List<Object>) GsonHelper.read(Files.readString(CUSTOM_MODULE_SAVE_PATH));
+			var path = AxolotlClientCommon.resolveProfileConfigFile(CUSTOM_MODULE_SAVE_FILE_NAME);
+			if (Files.exists(path)) {
+				var obj = (List<Object>) GsonHelper.read(Files.readString(path));
 				obj.forEach(o -> {
 					CustomHudEntry entry = new CustomHudEntry();
 					var values = (Map<String, Object>) o;
@@ -166,8 +167,9 @@ public abstract class HudManagerCommon extends AbstractCommonModule {
 
 	public void saveCustomEntries() {
 		try {
-			Files.createDirectories(CUSTOM_MODULE_SAVE_PATH.getParent());
-			var writer = Files.newBufferedWriter(CUSTOM_MODULE_SAVE_PATH);
+			var path = AxolotlClientCommon.resolveProfileConfigFile(CUSTOM_MODULE_SAVE_FILE_NAME);
+			Files.createDirectories(path.getParent());
+			var writer = Files.newBufferedWriter(path);
 			var json = new JsonWriter(writer);
 			json.beginArray();
 			for (Map.Entry<AxoIdentifier, HudEntry> entry : entries.entrySet()) {
@@ -274,6 +276,17 @@ public abstract class HudManagerCommon extends AbstractCommonModule {
 			.stream()
 			.map(Positionable::getTrueBounds)
 			.collect(Collectors.toList());
+	}
+
+	@Override
+	public void reloadConfig() {
+		entries.entrySet().removeIf(entry -> entry.getValue() instanceof CustomHudEntry);
+		loadCustomEntries();
+		for (var hud : getEntries()) {
+			if (hud instanceof ProfileAware p) {
+				p.reloadConfig();
+			}
+		}
 	}
 
 	protected abstract void openScreen();

--- a/common/src/main/resources/assets/axolotlclient/lang/en_us.json
+++ b/common/src/main/resources/assets/axolotlclient/lang/en_us.json
@@ -778,5 +778,15 @@
 	"graphics.copy_text": "Export to Clipboard",
 	"graphics.paste_text": "Import from Clipboard",
 	"graphics.paste_text.failed": "Import Failed",
-	"graphics.paste_text.failed.desc": "The clipboard does not contain valid data!"
+	"graphics.paste_text.failed.desc": "The clipboard does not contain valid data!",
+	"profiles.title": "Profiles",
+	"profiles.configure": "Manage",
+	"profiles.configure.list": "Manage Profiles",
+	"profiles.profile.load": "Load",
+	"profiles.profile.remove": "Remove",
+	"profiles.profile.default_new_name": "New Profile",
+	"profiles.duplicated": "%s - Copy",
+	"profiles.profile.duplicate": "Duplicate",
+	"profiles.profile.current": "Current!",
+	"profiles.profile.add": "Add empty Profile"
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,7 +7,7 @@ fabric.loom.disableMinecraftVerification=true
 axolotlclient.modules.all=true
 
 # Mod Properties
-version=3.1.5-alpha.1
+version=3.1.5-alpha.1-profiles
 
 maven_group=io.github.axolotlclient
 


### PR DESCRIPTION
Implements config profiles and a screen to manage them as well as switch between them.

Previous configs will be migrated to the automatically created "default" profile.

Note: Accounts are not stored in the profile config folders, they remain global. This is intentional to prevent unintentional sharing of account details (even if only tokens are saved) when sharing config files.